### PR TITLE
Fix decaffeinated functions

### DIFF
--- a/src/g/package.js
+++ b/src/g/package.js
@@ -30,7 +30,7 @@ module.exports = Package = Model.extend({
       }
       ), pkgs.length
       );
-      return pkgs.forEach((pkg) => {
+      return pkgs.forEach(function (pkg) {
         return this.loadPackage(pkg, cbs);
       });
   },

--- a/src/menu/views/ColorMenu.js
+++ b/src/menu/views/ColorMenu.js
@@ -47,7 +47,7 @@ module.exports = ColorMenu = MenuBuilder.extend({
       style.backgroundColor = "#77ED80";
     }
 
-    return this.addNode(scheme.name, () => {
+    return this.addNode(scheme.name, function () {
       this.g.colorscheme.set("scheme", scheme.id)
     }, {
         style: style

--- a/src/menu/views/DebugMenu.js
+++ b/src/menu/views/DebugMenu.js
@@ -11,21 +11,21 @@ module.exports = DebugMenu = MenuBuilder.extend({
   render: function() {
     this.setName("Debug");
 
-    this.addNode("Get the code", () => {
+    this.addNode("Get the code", function () {
       return window.open("https://github.com/wilzbach/msa");
     });
 
-    this.addNode("Toggle mouseover events", () => {
+    this.addNode("Toggle mouseover events", function () {
       this.g.config.set("registerMouseHover", !this.g.config.get("registerMouseHover"));
       return this.g.onAll(function() {
         return console.log(arguments);
       });
     });
 
-    this.addNode("Minimized width", () => {
+    this.addNode("Minimized width", function () {
       return this.g.zoomer.set("alignmentWidth", 600);
     });
-    this.addNode("Minimized height", () => {
+    this.addNode("Minimized height", function () {
       return this.g.zoomer.set("alignmentHeight", 120);
     });
 

--- a/src/menu/views/ExportMenu.js
+++ b/src/menu/views/ExportMenu.js
@@ -15,19 +15,19 @@ module.exports = ExportMenu = MenuBuilder.extend({
   render: function() {
     this.setName("Export");
 
-    this.addNode("Share view (URL) ↪", () => {
+    this.addNode("Share view (URL) ↪", function () {
       return Exporter.shareLink(this.msa, function(link) {
         return window.open(link, '_blank');
       });
     });
 
-    this.addNode("View in Jalview", () => {
+    this.addNode("View in Jalview", function () {
       var url = this.g.config.get('url');
       if (!(typeof url !== "undefined" && url !== null)) {
         return alert("Sequence weren't imported via an URL");
       } else {
         if (url.indexOf("localhost" || url === "dragimport")) {
-          return Exporter.publishWeb(this.msa, (link) => {
+          return Exporter.publishWeb(this.msa, function (link) {
             return Exporter.openInJalview(link, this.g.colorscheme.get("scheme"));
           });
         } else {
@@ -36,25 +36,25 @@ module.exports = ExportMenu = MenuBuilder.extend({
       }
     });
 
-    this.addNode("Export alignment (FASTA)", () => {
+    this.addNode("Export alignment (FASTA)", function () {
       return Exporter.saveAsFile(this.msa, "all.fasta");
     });
 
-    this.addNode("Export alignment (URL)", () => {
+    this.addNode("Export alignment (URL)", function () {
       return Exporter.publishWeb(this.msa, function(link) {
         return window.open(link, '_blank');
       });
     });
 
-    this.addNode("Export selected sequences (FASTA)", () => {
+    this.addNode("Export selected sequences (FASTA)", function () {
       return Exporter.saveSelection(this.msa, "selection.fasta");
     });
 
-    this.addNode("Export features (GFF)", () => {
+    this.addNode("Export features (GFF)", function () {
       return Exporter.saveAnnots(this.msa, "features.gff3");
     });
 
-    this.addNode("Export MSA image (PNG)", () => {
+    this.addNode("Export MSA image (PNG)", function () {
       return Exporter.saveAsImg(this.msa, "biojs-msa.png");
     });
 

--- a/src/menu/views/ExtraMenu.js
+++ b/src/menu/views/ExtraMenu.js
@@ -16,7 +16,7 @@ module.exports = ExtraMenu = MenuBuilder.extend({
     this.setName("Extras");
     var stats = this.g.stats;
     var msa = this.msa;
-    this.addNode("Add consensus seq", () => {
+    this.addNode("Add consensus seq", function () {
       var con = stats.consensus();
       var seq = new Seq({
         seq: con,
@@ -57,7 +57,7 @@ module.exports = ExtraMenu = MenuBuilder.extend({
     //     s.set "branch_length", 2
     //   cbs()
 
-    this.addNode("Increase font size", () => {
+    this.addNode("Increase font size", function () {
       var columnWidth =  this.g.zoomer.get("columnWidth");
       var nColumnWidth = columnWidth + 5;
       this.g.zoomer.set("columnWidth",  nColumnWidth);
@@ -66,7 +66,7 @@ module.exports = ExtraMenu = MenuBuilder.extend({
       this.g.zoomer.set("residueFont", nFontSize);
       return this.g.zoomer.set("labelFontSize",  nFontSize);
     });
-    this.addNode("Decrease font size", () => {
+    this.addNode("Decrease font size", function () {
       var columnWidth =  this.g.zoomer.get("columnWidth");
       var nColumnWidth = columnWidth - 2;
       this.g.zoomer.set("columnWidth",  nColumnWidth);
@@ -81,7 +81,7 @@ module.exports = ExtraMenu = MenuBuilder.extend({
     });
 
 
-    this.addNode("Jump to a column", () => {
+    this.addNode("Jump to a column", function () {
       var offset = prompt("Column", "20");
       if (offset < 0 || offset > this.model.getMaxLength() || isNaN(offset)) {
         alert("invalid column");

--- a/src/menu/views/FilterMenu.js
+++ b/src/menu/views/FilterMenu.js
@@ -11,7 +11,7 @@ module.exports = FilterMenu = MenuBuilder.extend({
 
   render: function() {
     this.setName("Filter");
-    this.addNode("Hide columns by threshold",(e) => {
+    this.addNode("Hide columns by threshold",function (e) {
       var threshold = prompt("Enter threshold (in percent)", 20);
       threshold = threshold / 100;
       var maxLen = this.model.getMaxLength();
@@ -27,14 +27,14 @@ module.exports = FilterMenu = MenuBuilder.extend({
       return this.g.columns.set("hidden", hidden);
     });
 
-    this.addNode("Hide columns by selection", () => {
+    this.addNode("Hide columns by selection", function () {
       var hiddenOld = this.g.columns.get("hidden");
       var hidden = hiddenOld.concat(this.g.selcol.getAllColumnBlocks({maxLen: this.model.getMaxLength(), withPos: true}));
       this.g.selcol.reset([]);
       return this.g.columns.set("hidden", hidden);
     });
 
-    this.addNode("Hide columns by gaps", () => {
+    this.addNode("Hide columns by gaps", function () {
       var threshold = prompt("Enter threshold (in percent)", 20);
       threshold = threshold / 100;
       var maxLen = this.model.getMaxLength();
@@ -55,7 +55,7 @@ module.exports = FilterMenu = MenuBuilder.extend({
       return this.g.columns.set("hidden", hidden);
     });
 
-    this.addNode("Hide seqs by identity", () => {
+    this.addNode("Hide seqs by identity", function () {
       var threshold = prompt("Enter threshold (in percent)", 20);
       threshold = threshold / 100;
       return this.model.each(function(el) {
@@ -65,7 +65,7 @@ module.exports = FilterMenu = MenuBuilder.extend({
       });
     });
 
-    this.addNode("Hide seqs by selection", () => {
+    this.addNode("Hide seqs by selection", function () {
       var hidden = this.g.selcol.where({type: "row"});
       var ids = _.map(hidden, function(el) { return el.get('seqId'); });
       this.g.selcol.reset([]);
@@ -76,7 +76,7 @@ module.exports = FilterMenu = MenuBuilder.extend({
       });
     });
 
-    this.addNode("Hide seqs by gaps", () => {
+    this.addNode("Hide seqs by gaps", function () {
       var threshold = prompt("Enter threshold (in percent)", 40);
       return this.model.each(function(el,i) {
         var seq = el.get('seq');
@@ -87,7 +87,7 @@ module.exports = FilterMenu = MenuBuilder.extend({
       });
     });
 
-    this.addNode("Reset", () => {
+    this.addNode("Reset", function () {
       this.g.columns.set("hidden", []);
       return this.model.each(function(el) {
         if (el.get('hidden')) {

--- a/src/menu/views/HelpMenu.js
+++ b/src/menu/views/HelpMenu.js
@@ -9,13 +9,13 @@ module.exports = HelpMenu = MenuBuilder.extend({
 
   render: function() {
     this.setName("Help");
-    this.addNode("About the project", () => {
+    this.addNode("About the project", function () {
       return window.open("https://github.com/wilzbach/msa");
     });
-    this.addNode("Report issues", () => {
+    this.addNode("Report issues", function () {
       return window.open("https://github.com/wilzbach/msa/issues");
     });
-    this.addNode("User manual", () => {
+    this.addNode("User manual", function () {
       return window.open("https://github.com/wilzbach/msa/wiki");
     });
     this.el.style.display = "inline-block";

--- a/src/menu/views/ImportMenu.js
+++ b/src/menu/views/ImportMenu.js
@@ -29,7 +29,7 @@ module.exports = ImportMenu = MenuBuilder.extend({
     var filetypes = "(Fasta, Clustal, GFF, Jalview features, Newick)";
 
     this.setName("Import");
-    this.addNode("URL",(e) => {
+    this.addNode("URL",function (e) {
       var url = prompt( "URL " + filetypes,
       "http://rostlab.org/~goldberg/clustalw2-I20140818-215249-0556-53699878-pg.clustalw"
       );
@@ -45,11 +45,11 @@ module.exports = ImportMenu = MenuBuilder.extend({
         //zoomer.boxRectWidth = 2
         //@g.zoomer.set zoomer
 
-    this.addNode("From file " + filetypes, () => {
+    this.addNode("From file " + filetypes, function () {
       return uploader.click();
     });
 
-    this.addNode("Drag & Drop", () => {
+    this.addNode("Drag & Drop", function () {
       return alert("Yep. Just drag & drop your file " + filetypes);
     });
 

--- a/src/menu/views/OrderingMenu.js
+++ b/src/menu/views/OrderingMenu.js
@@ -41,7 +41,7 @@ module.exports = OrderingMenu = MenuBuilder.extend({
     if (text === this.order) {
       style.backgroundColor = "#77ED80";
     }
-    return this.addNode(text, (() => {
+    return this.addNode(text, (function () {
       if ((m.precode != null)) { m.precode(); }
       this.model.comparator = m.comparator;
       this.model.sort();
@@ -75,19 +75,19 @@ module.exports = OrderingMenu = MenuBuilder.extend({
         return - a.get("seq").localeCompare(b.get("seq"));
     }});
 
-    var setIdent = () => {
+    var setIdent = function () {
       return this.ident = this.g.stats.identity();
     };
 
-    var setGaps = () => {
+    var setGaps = function () {
       this.gaps = {};
-      return this.model.each((el) => {
+      return this.model.each(function (el) {
         var seq = el.attributes.seq;
         return this.gaps[el.id] = (_.reduce(seq, (function(memo, c) { return c === '-' ? ++memo: undefined; }),0))/ seq.length;
       });
     };
 
-    models.push({text: "Identity ↑",comparator: ((a,b) => {
+    models.push({text: "Identity ↑",comparator: (function (a,b) {
       var val = this.ident[a.id] - this.ident[b.id];
       console.log(this.ident[a.id],this.ident[b.id]);
       if (val > 0) { return 1; }
@@ -96,7 +96,7 @@ module.exports = OrderingMenu = MenuBuilder.extend({
     }
     ), precode: setIdent});
 
-    models.push({text: "Identity ↓", comparator: ((a,b) => {
+    models.push({text: "Identity ↓", comparator: (function (a,b) {
       var val = this.ident[a.id] - this.ident[b.id];
       if (val > 0) { return -1; }
       if (val < 0) { return 1; }
@@ -104,7 +104,7 @@ module.exports = OrderingMenu = MenuBuilder.extend({
     }
     ), precode: setIdent});
 
-    models.push({text: "Gaps ↑", comparator: ((a,b) => {
+    models.push({text: "Gaps ↑", comparator: (function (a,b) {
       var val = this.gaps[a.id] - this.gaps[b.id];
       if (val > 0) { return 1; }
       if (val < 0) { return -1; }
@@ -112,7 +112,7 @@ module.exports = OrderingMenu = MenuBuilder.extend({
     }
     ), precode: setGaps});
 
-    models.push({text: "Gaps ↓", comparator: ((a,b) => {
+    models.push({text: "Gaps ↓", comparator: (function (a,b) {
       var val = this.gaps[a.id] - this.gaps[b.id];
       if (val < 0) { return 1; }
       if (val > 0) { return -1; }

--- a/src/menu/views/SelectionMenu.js
+++ b/src/menu/views/SelectionMenu.js
@@ -10,12 +10,12 @@ module.exports = SelectionMenu = MenuBuilder.extend({
 
   render() {
     this.setName("Selection");
-    this.addNode("Find Motif (supports RegEx)", () => {
+    this.addNode("Find Motif (supports RegEx)", function () {
       var search = prompt("your search", "D");
       return this.g.user.set("searchText", search);
     });
 
-    this.addNode("Invert columns", () => {
+    this.addNode("Invert columns", function () {
       return this.g.selcol.invertCol(((function() {
         var result = [];
         var end = this.model.getMaxLength();
@@ -32,10 +32,10 @@ module.exports = SelectionMenu = MenuBuilder.extend({
         return result;
       })()));
     });
-    this.addNode("Invert rows", () => {
+    this.addNode("Invert rows", function () {
       return this.g.selcol.invertRow(this.model.pluck("id"));
     });
-    this.addNode("Reset", () => {
+    this.addNode("Reset", function () {
       return this.g.selcol.reset();
     });
     this.el.appendChild(this.buildDOM());

--- a/src/menu/views/VisMenu.js
+++ b/src/menu/views/VisMenu.js
@@ -21,7 +21,7 @@ module.exports = VisMenu = MenuBuilder.extend({
     }
 
     // other
-    this.addNode("Reset", () => {
+    this.addNode("Reset", function () {
       this.g.vis.set("labels", true);
       this.g.vis.set("sequences", true);
       this.g.vis.set("metacell", true);
@@ -54,7 +54,7 @@ module.exports = VisMenu = MenuBuilder.extend({
       style.color = "green";
     }
 
-    return this.addNode( (pre + visEl.name), (() => {
+    return this.addNode( (pre + visEl.name), (function () {
       return this.g.vis.set(visEl.id, ! this.g.vis.get(visEl.id));
     }
     ),

--- a/src/model/FeatureCol.js
+++ b/src/model/FeatureCol.js
@@ -44,7 +44,7 @@ module.exports = FeatureCol = Collection.extend({
   assignRows: function() {
 
     var len = (this.max(function(el) { return el.get("xEnd"); })).attributes.xEnd;
-    var rows = (() => {
+    var rows = (function () {
       var result = [];
       for (var x = 0; 0 < len ? x <= len : x >= len; 0 < len ? x++ : x--) {
         result.push(0);
@@ -78,7 +78,7 @@ module.exports = FeatureCol = Collection.extend({
   getMinRows: function() {
 
     var len = (this.max(function(el) { return el.get("xEnd"); })).attributes.xEnd;
-    var rows = ((() => {
+    var rows = ((function () {
       var result = [];
       for (var x = 0; 0 < len ? x <= len : x >= len; 0 < len ? x++ : x--) {
         result.push(0);
@@ -87,7 +87,7 @@ module.exports = FeatureCol = Collection.extend({
     })());
 
     this.each(function(el) {
-      return (() => {
+      return (function () {
         var result = [];
         var start = el.get("xStart");
         var end = el.get("xEnd");

--- a/src/model/SeqCollection.js
+++ b/src/model/SeqCollection.js
@@ -113,7 +113,7 @@ module.exports = SeqManager = Collection.extend({
 
   // rehash the sequence feature binding
   _bindSeqsWithFeatures: function() {
-    return this.each((seq) =>  this._bindSeqWithFeatures(seq));
+    return this.each(function (seq) { this._bindSeqWithFeatures(seq) });
   },
 
   // removes all features from the cache (not from the seqs)

--- a/src/model/SeqCollection.js
+++ b/src/model/SeqCollection.js
@@ -10,7 +10,7 @@ module.exports = SeqManager = Collection.extend({
     Collection.apply(this, arguments);
     this.g = g;
 
-    this.on( "add reset remove", (() => {
+    this.on( "add reset remove", (function () {
       // invalidate cache
       this.lengthCache = null;
       return this._bindSeqsWithFeatures();
@@ -18,7 +18,7 @@ module.exports = SeqManager = Collection.extend({
     );
 
     // use the first seq as reference as default
-    this.on("reset", () => {
+    this.on("reset", function () {
       return this._autoSetRefSeq();
     });
     this._autoSetRefSeq();
@@ -88,7 +88,7 @@ module.exports = SeqManager = Collection.extend({
     if (_.isEmpty(this.features)) {
       this.features = features;
     } else {
-      _.each(features, (val, key) => {
+      _.each(features, function (val, key) {
         if (!this.features.hasOwnProperty(key)) {
           return this.features[key] = val;
         } else {

--- a/src/msa.js
+++ b/src/msa.js
@@ -88,7 +88,7 @@ module.exports = boneView.extend({
     }
 
     if (data.importURL) {
-      this.u.file.importURL(data.importURL, () => {
+      this.u.file.importURL(data.importURL, function () {
         return this.render();
       });
     }
@@ -166,7 +166,7 @@ module.exports = boneView.extend({
       defMenu.render();
     }
 
-    return $(window).on("resize", (e) => {
+    return $(window).on("resize", function (e) {
       var f = function() {
         return this.g.zoomer.autoResize();
       };
@@ -191,7 +191,7 @@ module.exports = boneView.extend({
 
   startEventBus() {
     var busObjs = ["config", "columns", "colorscheme", "selcol" ,"vis", "visorder", "zoomer"];
-    return (() => {
+    return (function () {
       var result = [];
       for (var i = 0, key; i < busObjs.length; i++) {
         key = busObjs[i];

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -57,13 +57,13 @@ var funs =
   },
 
   importFiles: function(files) {
-    return (() => {
+    return (function () {
       var result = [];
       var end = files.length - 1;
       for (var i = 0; 0 < end ? i <= end : i >= end; 0 < end ? i++ : i--) {
         var file = files[i];
         var reader = new FileReader();
-        reader.onload = (evt) => {
+        reader.onload = function (evt) {
           return this.importFile(evt.target.result);
         };
         result.push(reader.readAsText(file));
@@ -85,7 +85,7 @@ var funs =
     } else if (type === "features") {
       this.msa.seqs.addFeatures(objs);
     } else if (type === "newick") {
-      this.msa.u.tree.loadTree(() => {
+      this.msa.u.tree.loadTree(function () {
         return this.msa.u.tree.showTree(file);
       });
     }
@@ -99,7 +99,7 @@ var funs =
     return xhr({
         url: url,
         timeout: 0
-    }, (err,status,body) => {
+    }, function (err,status,body) {
       if (!err) {
         var res = this.importFile(body);
         if (res === "error") {

--- a/src/views/FeatureBlock.js
+++ b/src/views/FeatureBlock.js
@@ -30,7 +30,7 @@
 
     var yZero = data.y;
 
-    return (() => {
+    return (function () {
       var result = [];
       var end = seq.length - 1;
       for (var j = start; start < end ? j <= end : j >= end; start < end ? j++ : j--) {
@@ -49,7 +49,7 @@
 
         x = x + rectWidth;
         // out of viewport - stop
-        result.push((() => {
+        result.push((function () {
           if (x > this.el.width) {
             return;
           }

--- a/src/views/OverviewBox.js
+++ b/src/views/OverviewBox.js
@@ -153,8 +153,8 @@ module.exports = OverviewBox = view.extend({
       this.prolongSelection = false;
     }
     // enable global listeners
-    jbone(document.body).on('mousemove.overmove', (e) => this._onmousemove(e));
-    jbone(document.body).on('mouseup.overup', (e) => this._onmouseup(e));
+    jbone(document.body).on('mousemove.overmove', function (e) { this._onmousemove(e) });
+    jbone(document.body).on('mouseup.overup', function (e) { this._onmouseup(e) });
     return this.dragStart;
   },
 

--- a/src/views/Search.js
+++ b/src/views/Search.js
@@ -55,19 +55,19 @@ module.exports = boneView.extend({
   buildBtns: function() {
     var prevBtn = k.mk("button");
     prevBtn.textContent = "Prev";
-    prevBtn.addEventListener("click", () => {
+    prevBtn.addEventListener("click", function () {
       return this.moveSel(-1);
     });
 
     var nextBtn = k.mk("button");
     nextBtn.textContent = "Next";
-    nextBtn.addEventListener("click", () => {
+    nextBtn.addEventListener("click", function () {
       return this.moveSel(1);
     });
 
     var allBtn = k.mk("button");
     allBtn.textContent = "All";
-    allBtn.addEventListener("click", () => {
+    allBtn.addEventListener("click", function () {
       return this.g.selcol.reset(this.sel);
     });
 
@@ -106,7 +106,7 @@ module.exports = boneView.extend({
 
     this.model.each(function(seq) {
       var strSeq = seq.get("seq");
-      return (() => {
+      return (function () {
         var match;
         var result = [];
         while (match = search.exec(strSeq)) {

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -52,11 +52,11 @@ _.extend(SelectionClass.prototype, {
     if (selection.length === 0) { return; }
 
     var hiddenOffset = 0;
-    return (() => {
+    return (function () {
       var result = [];
       var end = seq.length - 1;
       for (var n = 0; 0 < end ? n <= end : n >= end; 0 < end ? n++ : n--) {
-        result.push((() => {
+        result.push((function () {
           if (data.hidden.indexOf(n) >= 0) {
             return hiddenOffset++;
           } else {

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -245,9 +245,9 @@ module.exports = boneView.extend({
   _onmousedown: function(e) {
     this.dragStart = mouse.abs(e);
     this.dragStartScroll = [this.g.zoomer.get('_alignmentScrollLeft'), this.g.zoomer.get('_alignmentScrollTop')];
-    jbone(document.body).on('mousemove.overmove', (e) => this._onmousemove(e));
-    jbone(document.body).on('mouseup.overup', () => this._cleanup());
-    //jbone(document.body).on 'mouseout.overout', (e) => @_onmousewinout(e)
+    jbone(document.body).on('mousemove.overmove', function (e) { this._onmousemove(e) });
+    jbone(document.body).on('mouseup.overup', function () { this._cleanup() });
+    //jbone(document.body).on 'mouseout.overout', function (e) { @_onmousewinout(e) }
     return e.preventDefault();
   },
 
@@ -255,8 +255,8 @@ module.exports = boneView.extend({
   _ontouchstart: function(e) {
     this.dragStart = mouse.abs(e.changedTouches[0]);
     this.dragStartScroll = [this.g.zoomer.get('_alignmentScrollLeft'), this.g.zoomer.get('_alignmentScrollTop')];
-    jbone(document.body).on('touchmove.overtmove', (e) => this._ontouchmove(e));
-    return jbone(document.body).on( 'touchend.overtend touchleave.overtleave touchcancel.overtcanel', (e) => this._touchCleanup(e)
+    jbone(document.body).on('touchmove.overtmove', function (e) { this._ontouchmove(e) });
+    return jbone(document.body).on( 'touchend.overtend touchleave.overtleave touchcancel.overtcanel', function (e) { this._touchCleanup(e) }
     );
   },
 

--- a/src/views/header/ConservationView.js
+++ b/src/views/header/ConservationView.js
@@ -65,7 +65,7 @@ var ConservationView = view.extend({
     var rowPos = evt.target.rowPos;
     var stepSize = this.g.zoomer.get("stepSize");
     // simulate hidden columns
-    return (() => {
+    return (function () {
       var result = [];
       var end = stepSize - 1;
       for (var i = 0; 0 < end ? i <= end : i >= end; 0 < end ? i++ : i--) {

--- a/src/views/header/GapView.js
+++ b/src/views/header/GapView.js
@@ -65,7 +65,7 @@ var ConservationView = view.extend({
     var rowPos = evt.target.rowPos;
     var stepSize = this.g.zoomer.get("stepSize");
     // simulate hidden columns
-    return (() => {
+    return (function () {
       var result = [];
       var end = stepSize - 1;
       for (var i = 0; 0 < end ? i <= end : i >= end; 0 < end ? i++ : i--) {

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -7,7 +7,7 @@ module.exports = boneView.extend({
   initialize: function(data) {
     this.g = data.g;
     this.draw();
-    return this.listenTo(this.g.vis,"change:labels change:metacell change:leftHeader", () => {
+    return this.listenTo(this.g.vis,"change:labels change:metacell change:leftHeader", function () {
       this.draw();
       return this.render();
     });

--- a/src/views/header/MarkerView.js
+++ b/src/views/header/MarkerView.js
@@ -82,7 +82,7 @@ var HeaderView = view.extend({
     s.style.position = "relative";
     var triangle = svg.polygon({points: "0,0 5,5 10,0", style:
       "fill:lime;stroke:purple;stroke-width:1"
-    });jbone(triangle).on("click", (evt) => {
+    });jbone(triangle).on("click", function (evt) {
       hidden.splice(index, length);
       return this.g.columns.set("hidden", hidden);
     });

--- a/src/views/labels/LabelBlock.js
+++ b/src/views/labels/LabelBlock.js
@@ -12,7 +12,7 @@ module.exports = boneView.extend({
     this.listenTo(this.g.zoomer,"change:alignmentHeight", this._setHeight);
     this.listenTo(this.model,"change:reference", this.draw);
 
-    return this.listenTo(this.model,"reset add remove", () => {
+    return this.listenTo(this.model,"reset add remove", function () {
       this.draw();
       return this.render();
     });


### PR DESCRIPTION
Seems to be a number of function calls written in coffee script rather than native javascript.

I'm assuming:

```
(e) => this.doSomething()
```

...is meant to read...

```
function (e) {
  this.doSomething();
}
```

I'm not familiar with coffeescript so this is a fair amount of guesswork. However I've applied a couple of find and replaces to apply a fix to all occurrences in ```src/```

1. fix multi-line functions:

```
perl -i -p -e 's#\(([^(]*)\)\s*=>\s*\{#function ($1) {#sm' \
`grep -l -R '=>' src`
```

2. fix single line functions:

```
perl -i -p -e 's#\(([^(]*)\)\s*=>\s*(.*?\))#function ($1) { $2 }#sm' \
 `grep -R -l '=>' src`
```

