### PR TITLE
add options for colouring conservation scores

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "biojs-vis-seqlogo": "^0.0.11",
     "blueimp_canvastoblob": "^1.0.0",
     "browser-saveas": "^1.0.0",
-    "d3-scale": "^0.7.0",
     "dom-helper": "^1.0.0",
     "jbone": "^1.1.2",
     "koala-js": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "biojs-vis-seqlogo": "^0.0.11",
     "blueimp_canvastoblob": "^1.0.0",
     "browser-saveas": "^1.0.0",
+    "d3-scale": "^0.7.0",
     "dom-helper": "^1.0.0",
     "jbone": "^1.1.2",
     "koala-js": "^1.0.7",

--- a/snippets/conserv.js
+++ b/snippets/conserv.js
@@ -9,7 +9,12 @@ var opts = {
   conserv: {
     maxHeight: 200,
     fillColor: ['blue', '#0f0'],
-    strokeColor: '#000'
+    strokeColor: '#000',
+    rectStyler: function (rect, data) { 
+      if ( data.rowPos < 10 ) {
+        rect.style.fill = "red" 
+      } 
+    }
   }
 };
 var m = new msa(opts);

--- a/snippets/conserv.js
+++ b/snippets/conserv.js
@@ -1,0 +1,16 @@
+/* global rootDiv */
+var msa = window.msa;
+var opts = {
+  el: rootDiv,
+  importURL: "./data/fer1.clustal",
+  vis: {
+    conserv: true,
+  },
+  conserv: {
+    maxHeight: 200,
+    fillColor: ['blue', '#0f0'],
+    strokeColor: '#000'
+  }
+};
+var m = new msa(opts);
+//@biojs-instance=m.g

--- a/src/msa.js
+++ b/src/msa.js
@@ -64,7 +64,7 @@ module.exports = boneView.extend({
     this.g.zoomer = new Zoomer(data.zoomer,{g:this.g, model: this.seqs});
     
     // store config options for plugins
-    this.g.conservationDefaults = data.conserv;
+    this.g.conservationConfig = data.conserv;
     
     // debug mode
     if (window.location.hostname === "localhost") {

--- a/src/msa.js
+++ b/src/msa.js
@@ -46,6 +46,7 @@ module.exports = boneView.extend({
     if (!(data.vis != null)) { data.vis = {}; }
     if (!(data.visorder != null)) { data.visorder = {}; }
     if (!(data.zoomer != null)) { data.zoomer = {}; }
+    if (!(data.conserv != null)) { data.conserv = {}; }
 
     // g is our global Mediator
     this.g = Eventhandler.mixin({});
@@ -61,7 +62,10 @@ module.exports = boneView.extend({
     this.g.vis = new Visibility(data.vis, {model: this.seqs});
     this.g.visorder = new VisOrdering(data.visorder);
     this.g.zoomer = new Zoomer(data.zoomer,{g:this.g, model: this.seqs});
-
+    
+    // store config options for plugins
+    this.g.conservationDefaults = data.conserv;
+    
     // debug mode
     if (window.location.hostname === "localhost") {
       this.g.config.set("debug", true);


### PR DESCRIPTION
Provides some more flexibility for specifying how conservation scores are displayed (including changing the colour according to the height of each bar).

See ```snippets/conserv``` for an example.

adds the following options to the main config:

```
conserv: {
	maxHeight: 20,
	fillColor: ['#660', '#ff0'],
	strokeColor: '#000'
}
```

```maxHeight``` is the height of the component (pixels) 

```fillColor``` / ```strokeColor```:

 - If a single value is given then all the elements are coloured the same
 - If a [min,max] range is given then each element is coloured in a sliding scale according to
the height.

Colours can be specified as anything that D3 understands e.g. "#00F", "rgb(0,0,1)", "blue" (see https://github.com/d3/d3-color)

NOTE: this adds ```d3-scale``` as a dependency which seems to add ~25K to the min.gz. I would argue that this is worth it as being able to interpolate (and translate) colours is pretty useful generally.