### PR TITLE
use es6 imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+	"presets": ["es2015"],
+	"plugins": ["transform-export-extensions"]
+}

--- a/package.json
+++ b/package.json
@@ -49,9 +49,10 @@
     "xhr": "^1.17.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.4.5",
-    "babel-loader": "^6.2.1",
+    "babel-cli": "^6.8.0",
+    "babel-core": "^6.8.0",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-export-extensions": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "biojs-io-newick": "git://github.com/wilzbach/biojs-io-newick",
     "chai": "^1.9.1",
@@ -74,7 +75,7 @@
     "through2": "^0.6.3",
     "tnt.tree": "0.0.10",
     "uglify-js": "~2.4.15",
-    "webpack": "^1.12.12"
+    "webpack": "^1.13.0"
   },
   "keywords": [
     "bio",
@@ -87,7 +88,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "echo 'temporarily disabled'",
-    "prepublish": "./node_modules/webpack/bin/webpack.js -p && gulp build && babel -d lib src --presets es2015",
+    "prepublish": "./node_modules/webpack/bin/webpack.js -p && gulp build && babel -d lib src",
     "build": "./node_modules/webpack/bin/webpack.js -p && gulp build",
     "sniper": "./node_modules/sniper/bin/sniper .",
     "watch": "./node_modules/webpack/bin/webpack.js -w",

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,42 @@
-var MSA = require("./msa");
+import MSA from "./msa";
 
-
-module.exports = window.msa = function() {
+const MSAWrapper = function() {
   var msa = function(args) {
     return MSA.apply(this, args);
   };
   msa.prototype = MSA.prototype;
   return new msa(arguments);
 };
+MSAWrapper.msa = MSA;
 
-module.exports.msa = MSA;
+export default MSAWrapper;
+export {MSA as msa};
 
 // models
-module.exports.model = require("./model");
+export * as model from "./model";
 
 // extra plugins, extensions
-module.exports.menu = require("./menu");
-module.exports.utils = require("./utils");
+export * as menu from "./menu";
+export {default as utils} from "./utils";
 
 // probably needed more often
-module.exports.selection = require("./g/selection/Selection");
-module.exports.selcol = require("./g/selection/SelectionCol");
-module.exports.view = require("backbone-viewj");
-module.exports.boneView = require("backbone-childs");
+export {default as selection} from  "./g/selection/Selection";
+export {default as selcol} from "./g/selection/SelectionCol";
+export {default as view} from "backbone-viewj";
+export {default as boneView} from "backbone-childs";
 
 // convenience
-module.exports._ = require('underscore');
-module.exports.$ = require('jbone');
+export {default as _} from 'underscore';
+export {default as $} from 'jbone';
 
 // parser (are currently bundled - so we can also expose them)
-module.exports.io = {};
-module.exports.io.xhr = require('xhr');
-module.exports.io.fasta = require('biojs-io-fasta');
-module.exports.io.clustal = require('biojs-io-clustal');
-module.exports.io.gff = require('biojs-io-gff');
+const io = {};
+io.xhr = require('xhr');
+io.fasta = require('biojs-io-fasta');
+io.clustal = require('biojs-io-clustal');
+io.gff = require('biojs-io-gff');
 
-module.exports.version = "0.2.0";
+export {io};
+
+//import {version} from '../package.json';
+//module.exports.version = version;

--- a/src/index_webpack.js
+++ b/src/index_webpack.js
@@ -1,3 +1,7 @@
 // trick to bundle the css
-require('./../css/msa.css')
-module.exports = require('./index')
+require('./../css/msa.css');
+import * as MSA from "./index";
+if (!!window) {
+    window.msa = MSA;
+}
+export default MSA;

--- a/src/menu/defaultmenu.js
+++ b/src/menu/defaultmenu.js
@@ -1,21 +1,20 @@
-var MenuView;
-var boneView = require("backbone-childs");
+const boneView = require("backbone-childs");
 
 // menu views
-var ImportMenu = require("./views/ImportMenu");
-var FilterMenu = require("./views/FilterMenu");
-var SelectionMenu = require("./views/SelectionMenu");
-var VisMenu = require("./views/VisMenu");
-var ColorMenu = require("./views/ColorMenu");
-var OrderingMenu = require("./views/OrderingMenu");
-var ExtraMenu = require("./views/ExtraMenu");
-var ExportMenu = require("./views/ExportMenu");
-var HelpMenu = require("./views/HelpMenu");
-var DebugMenu = require("./views/DebugMenu");
-var MenuSettings = require("./settings");
+import ImportMenu from "./views/ImportMenu";
+import FilterMenu from "./views/FilterMenu";
+import SelectionMenu from "./views/SelectionMenu";
+import VisMenu from "./views/VisMenu";
+import ColorMenu from "./views/ColorMenu";
+import OrderingMenu from "./views/OrderingMenu";
+import ExtraMenu from "./views/ExtraMenu";
+import ExportMenu from "./views/ExportMenu";
+import HelpMenu from "./views/HelpMenu";
+import DebugMenu from "./views/DebugMenu";
+import MenuSettings from "./settings";
 
 // this very basic menu demonstrates calls to the MSA component
-module.exports = MenuView = boneView.extend({
+const MenuView = boneView.extend({
 
   initialize: function(data) {
     if(!data.msa){
@@ -47,3 +46,4 @@ module.exports = MenuView = boneView.extend({
     return this.el.appendChild(document.createElement("p"));
   }
 });
+export default MenuView;

--- a/src/menu/index.js
+++ b/src/menu/index.js
@@ -1,2 +1,5 @@
-module.exports.defaultmenu = require("./defaultmenu");
-module.exports.menubuilder = require("./menubuilder");
+//import defaultmenu from "./defaultmenu";
+//import menubuilder from "./menubuilder";
+export {default as defaultmenu} from "./defaultmenu";
+export {default as menubuilder} from "./menubuilder";
+//export default {defaultmenu, menubuilder};

--- a/src/menu/menubuilder.js
+++ b/src/menu/menubuilder.js
@@ -1,7 +1,6 @@
-var MenuBuilder;
-var builder = require("menu-builder");
+const builder = require("menu-builder");
 
-module.exports = MenuBuilder = builder.extend({
+const MenuBuilder = builder.extend({
 
     buildDOM: function() {
       this.on("new:node", this.buildNode);
@@ -30,3 +29,4 @@ module.exports = MenuBuilder = builder.extend({
       }
     }
 });
+export default MenuBuilder;

--- a/src/menu/settings.js
+++ b/src/menu/settings.js
@@ -1,6 +1,5 @@
-var MenuSettings;
-var Model = require("backbone-thin").Model;
-module.exports = MenuSettings = Model.extend({
+const Model = require("backbone-thin").Model;
+const MenuSettings = Model.extend({
     constructor: function(attributes,options) {
         if(attributes == "small"){
             attributes = this.small;
@@ -18,3 +17,4 @@ module.exports = MenuSettings = Model.extend({
         menuPadding: "3px 4px 3px 4px"
     }
 });
+export default MenuSettings;

--- a/src/menu/views/ColorMenu.js
+++ b/src/menu/views/ColorMenu.js
@@ -1,9 +1,8 @@
-var ColorMenu;
-var MenuBuilder = require("../menubuilder");
-var _ = require("underscore");
-var dom = require("dom-helper");
+import MenuBuilder from "../menubuilder";
+const _ = require("underscore");
+const dom = require("dom-helper");
 
-module.exports = ColorMenu = MenuBuilder.extend({
+const ColorMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -113,3 +112,4 @@ module.exports = ColorMenu = MenuBuilder.extend({
     //     seq.set "grey", []
   }
 });
+export default ColorMenu;

--- a/src/menu/views/DebugMenu.js
+++ b/src/menu/views/DebugMenu.js
@@ -1,7 +1,6 @@
-var DebugMenu;
-var MenuBuilder = require("../menubuilder");
+import MenuBuilder from "../menubuilder";
 
-module.exports = DebugMenu = MenuBuilder.extend({
+const DebugMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -33,3 +32,4 @@ module.exports = DebugMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default DebugMenu;

--- a/src/menu/views/ExportMenu.js
+++ b/src/menu/views/ExportMenu.js
@@ -1,10 +1,9 @@
-var ExportMenu;
-var MenuBuilder = require("../menubuilder");
-var FastaExporter = require("biojs-io-fasta").writer;
-var _ = require("underscore");
-var Exporter = require("../../utils/export");
+import MenuBuilder from "../menubuilder";
+const FastaExporter = require("biojs-io-fasta").writer;
+const _ = require("underscore");
+const Exporter = require("../../utils/export");
 
-module.exports = ExportMenu = MenuBuilder.extend({
+const ExportMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -62,3 +61,4 @@ module.exports = ExportMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default ExportMenu;

--- a/src/menu/views/ExtraMenu.js
+++ b/src/menu/views/ExtraMenu.js
@@ -1,10 +1,9 @@
-var ExtraMenu;
-var MenuBuilder = require("../menubuilder");
-var Seq = require("../../model/Sequence");
-var Loader = require("../../utils/loader");
-var xhr = require("xhr");
+import MenuBuilder from "../menubuilder";
+import Seq from "../../model/Sequence";
+const Loader = require("../../utils/loader");
+const xhr = require("xhr");
 
-module.exports = ExtraMenu = MenuBuilder.extend({
+const ExtraMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -94,3 +93,4 @@ module.exports = ExtraMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default ExtraMenu;

--- a/src/menu/views/FilterMenu.js
+++ b/src/menu/views/FilterMenu.js
@@ -1,8 +1,7 @@
-var FilterMenu;
-var MenuBuilder = require("../menubuilder");
-var _ = require("underscore");
+import MenuBuilder from "../menubuilder";
+const _ = require("underscore");
 
-module.exports = FilterMenu = MenuBuilder.extend({
+const FilterMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -100,3 +99,4 @@ module.exports = FilterMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default FilterMenu;

--- a/src/menu/views/HelpMenu.js
+++ b/src/menu/views/HelpMenu.js
@@ -1,7 +1,6 @@
-var HelpMenu;
-var MenuBuilder = require("../menubuilder");
+import MenuBuilder from "../menubuilder";
 
-module.exports = HelpMenu = MenuBuilder.extend({
+const HelpMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     return this.g = data.g;
@@ -23,3 +22,4 @@ module.exports = HelpMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default HelpMenu;

--- a/src/menu/views/ImportMenu.js
+++ b/src/menu/views/ImportMenu.js
@@ -1,8 +1,7 @@
-var ImportMenu;
-var MenuBuilder = require("../menubuilder");
-var k = require("koala-js");
+import MenuBuilder from "../menubuilder";
+const k = require("koala-js");
 
-module.exports = ImportMenu = MenuBuilder.extend({
+const ImportMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -57,3 +56,4 @@ module.exports = ImportMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default ImportMenu;

--- a/src/menu/views/OrderingMenu.js
+++ b/src/menu/views/OrderingMenu.js
@@ -1,9 +1,8 @@
-var OrderingMenu;
-var MenuBuilder = require("../menubuilder");
-var dom = require("dom-helper");
-var _ = require('underscore');
+import MenuBuilder from "../menubuilder";
+const dom = require("dom-helper");
+const _ = require('underscore');
 
-module.exports = OrderingMenu = MenuBuilder.extend({
+const OrderingMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -134,3 +133,4 @@ module.exports = OrderingMenu = MenuBuilder.extend({
     return models;
   }
 });
+export default OrderingMenu;

--- a/src/menu/views/SelectionMenu.js
+++ b/src/menu/views/SelectionMenu.js
@@ -1,7 +1,6 @@
-var SelectionMenu;
-var MenuBuilder = require("../menubuilder");
+import MenuBuilder from "../menubuilder";
 
-module.exports = SelectionMenu = MenuBuilder.extend({
+const SelectionMenu = MenuBuilder.extend({
 
   initialize(data) {
     this.g = data.g;
@@ -42,3 +41,4 @@ module.exports = SelectionMenu = MenuBuilder.extend({
     return this;
   }
 });
+export default SelectionMenu;

--- a/src/menu/views/VisMenu.js
+++ b/src/menu/views/VisMenu.js
@@ -1,8 +1,7 @@
-var VisMenu;
-var MenuBuilder = require("../menubuilder");
+import MenuBuilder from "../menubuilder";
 var dom = require("dom-helper");
 
-module.exports = VisMenu = MenuBuilder.extend({
+const VisMenu = MenuBuilder.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -82,3 +81,4 @@ module.exports = VisMenu = MenuBuilder.extend({
     return vis;
   }
 });
+export default VisMenu;

--- a/src/model/Feature.js
+++ b/src/model/Feature.js
@@ -1,7 +1,5 @@
-var Feature = require("./Feature");
 var Model = require("backbone-thin").Model;
-
-module.exports = Feature = Model.extend({
+const Feature = Model.extend({
 
   defaults:
     {xStart: -1,
@@ -59,4 +57,4 @@ module.exports = Feature = Model.extend({
     return  this.attributes.xStart <= index && index <= this.attributes.xEnd;
   }
 });
-
+export default Feature;

--- a/src/model/FeatureCol.js
+++ b/src/model/FeatureCol.js
@@ -1,9 +1,8 @@
-var FeatureCol;
-var Feature = require("./Feature");
-var Collection = require("backbone-thin").Collection;
-var _ = require("underscore");
+const Feature = require("./Feature");
+const Collection = require("backbone-thin").Collection;
+import _ from "underscore";
 
-module.exports = FeatureCol = Collection.extend({
+const FeatureCol = Collection.extend({
   model: Feature,
 
   constructor: function() {
@@ -101,3 +100,4 @@ module.exports = FeatureCol = Collection.extend({
     return _.max(rows);
   }
 });
+export default FeatureCol;

--- a/src/model/SeqCollection.js
+++ b/src/model/SeqCollection.js
@@ -1,9 +1,8 @@
-var SeqManager;
-var Sequence = require("./Sequence");
-var FeatureCol = require("./FeatureCol");
-var Collection = require("backbone-thin").Collection;
+import Sequence from "./Sequence";
+import FeatureCol from "./FeatureCol";
+const Collection = require("backbone-thin").Collection;
 
-module.exports = SeqManager = Collection.extend({
+const SeqCollection = Collection.extend({
   model: Sequence,
 
   constructor: function(seqs, g) {
@@ -144,3 +143,4 @@ module.exports = SeqManager = Collection.extend({
     return this.trigger("change:reference", seq);
   }
 });
+export default SeqCollection;

--- a/src/model/Sequence.js
+++ b/src/model/Sequence.js
@@ -1,8 +1,7 @@
-var Sequence;
-var Model = require("backbone-thin").Model;
-var FeatureCol = require("./FeatureCol");
+const Model = require("backbone-thin").Model;
+import FeatureCol from "./FeatureCol";
 
-module.exports = Sequence = Model.extend({
+const Sequence = Model.extend({
 
   defaults: {
     name: "",
@@ -20,3 +19,4 @@ module.exports = Sequence = Model.extend({
     }
   }
 });
+export default Sequence;

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,4 +1,4 @@
-module.exports.seq = require("./Sequence");
-module.exports.seqcol = require("./SeqCollection");
-module.exports.feature = require("./Feature");
-module.exports.featurecol = require("./FeatureCol");
+export {default as seq} from "./Sequence";
+export {default as seqcol} from "./SeqCollection";
+export {default as feature} from "./Feature";
+export {default as featurecol} from "./FeatureCol";

--- a/src/msa.js
+++ b/src/msa.js
@@ -1,32 +1,32 @@
 // models
-var SeqCollection = require("./model/SeqCollection");
+import SeqCollection from "./model/SeqCollection";
 
 // globals
-var Colorator = require("./g/colorscheme");
-var Columns = require("./g/columns");
-var Config = require("./g/config");
-var Package = require("./g/package");
-var SelCol = require("./g/selection/SelectionCol");
-var User = require("./g/user");
-var Visibility = require("./g/visibility");
-var VisOrdering = require("./g/visOrdering");
-var Zoomer = require("./g/zoomer");
+import Colorator from "./g/colorscheme";
+import Columns from "./g/columns";
+import Config from "./g/config";
+import Package from "./g/package";
+import SelCol from "./g/selection/SelectionCol";
+import User from "./g/user";
+import Visibility from "./g/visibility";
+import VisOrdering from "./g/visOrdering";
+import Zoomer from "./g/zoomer";
 
 // MV from backbone
-var boneView = require("backbone-childs");
-var Eventhandler = require("biojs-events");
+const boneView = require("backbone-childs");
+const Eventhandler = require("biojs-events");
 
 // MSA views
-var Stage = require("./views/Stage");
+import Stage from "./views/Stage";
 
 // statistics
-var Stats = require("stat.seqs");
+const Stats = require("stat.seqs");
 
 // utils
-var $ = require("jbone");
-var FileHelper = require("./utils/file");
-var TreeHelper = require("./utils/tree");
-var ProxyHelper = require("./utils/proxy");
+const $ = require("jbone");
+import FileHelper from "./utils/file";
+import TreeHelper from "./utils/tree";
+import ProxyHelper from "./utils/proxy";
 
 // opts is a dictionary consisting of
 // @param el [String] id or reference to a DOM element
@@ -34,7 +34,7 @@ var ProxyHelper = require("./utils/proxy");
 // @param conf [Dict] user config
 // @param vis [Dict] config of visible views
 // @param zoomer [Dict] display settings like columnWidth
-module.exports = boneView.extend({
+const MSA = boneView.extend({
 
   initialize: function(data) {
 
@@ -223,3 +223,4 @@ module.exports = boneView.extend({
     return this;
   }
 });
+export default MSA;

--- a/src/utils/bmath.js
+++ b/src/utils/bmath.js
@@ -1,4 +1,4 @@
-module.exports =
+export default
   // math utilities
   class BMath {
     static randomInt(lower, upper) {

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -1,12 +1,11 @@
-var Exporter;
-var Fasta = require("biojs-io-fasta");
-var GFF = require("biojs-io-gff");
-var xhr = require("xhr");
-var blobURL = require("blueimp_canvastoblob");
-var saveAs = require("browser-saveas");
-var _ = require("underscore");
+const Fasta = require("biojs-io-fasta");
+const GFF = require("biojs-io-gff");
+const xhr = require("xhr");
+const blobURL = require("blueimp_canvastoblob");
+const saveAs = require("browser-saveas");
+const _ = require("underscore");
 
-module.exports = Exporter =
+const Exporter =
 
   {openInJalview: function(url, colorscheme) {
     if (url.charAt(0) === '.') {
@@ -115,3 +114,4 @@ module.exports = Exporter =
       }
   }
   };
+export default Exporter;

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,11 +1,10 @@
-var FileHelper;
-var FastaReader = require("biojs-io-fasta");
-var ClustalReader = require("biojs-io-clustal");
-var GffReader = require("biojs-io-gff");
-var _ = require("underscore");
-var xhr = require("xhr");
+const FastaReader = require("biojs-io-fasta");
+const ClustalReader = require("biojs-io-clustal");
+const GffReader = require("biojs-io-gff");
+const _ = require("underscore");
+const xhr = require("xhr");
 
-module.exports = FileHelper = function(msa) {
+const FileHelper = function(msa) {
   this.msa = msa;
   return this;
 };
@@ -117,3 +116,4 @@ var funs =
   };
 
 _.extend(FileHelper.prototype, funs);
+export default FileHelper;

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -1,7 +1,6 @@
-var loader;
-var k = require("koala-js");
+const k = require("koala-js");
 
-module.exports = loader =
+const Loader =
 
   // asynchronously require a script
   {loadScript: function(url, cb) {
@@ -50,3 +49,4 @@ module.exports = loader =
     return callbackWrapper;
   }
   };
+export default Loader;

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -1,7 +1,6 @@
-var ProxyHelper;
-var _ = require("underscore");
+const _ = require("underscore");
 
-module.exports = ProxyHelper = function(opts) {
+const ProxyHelper = function(opts) {
   this.g = opts.g;
   return this;
 };
@@ -29,3 +28,4 @@ var proxyFun =
   };
 
 _.extend(ProxyHelper.prototype, proxyFun);
+export default ProxyHelper;

--- a/src/utils/seqgen.js
+++ b/src/utils/seqgen.js
@@ -1,8 +1,8 @@
-var Sequence = require("biojs-model").seq;
-var BMath = require("./bmath");
-var Stat = require("stat.seqs");
+const Sequence = require("biojs-model").seq;
+import BMath from "./bmath";
+const Stat = require("stat.seqs");
 
-var seqgen = module.exports =
+const SeqGen =
   {_generateSequence: function(len) {
     var text = "";
     var end = len - 1;
@@ -79,3 +79,4 @@ var seqgen = module.exports =
     return pseqs;
   }
   };
+export default SeqGen;

--- a/src/utils/svg.js
+++ b/src/utils/svg.js
@@ -1,8 +1,8 @@
 // mini svg helper
 
-var svgns = "http://www.w3.org/2000/svg";
+const svgns = "http://www.w3.org/2000/svg";
 
-var setAttr = function(obj,opts) {
+const setAttr = function(obj,opts) {
   for (var name in opts) {
     var value = opts[name];
     obj.setAttributeNS(null, name, value);
@@ -10,29 +10,27 @@ var setAttr = function(obj,opts) {
   return obj;
 };
 
-var Base = function(opts) {
+const Base = function(opts) {
   var svg = document.createElementNS(svgns, 'svg');
   svg.setAttribute("width", opts.width);
   svg.setAttribute("height", opts.height);
   return svg;
 };
 
-var Rect = function(opts) {
+const Rect = function(opts) {
   var rect = document.createElementNS(svgns, 'rect');
   return setAttr(rect,opts);
 };
 
-var Line = function(opts) {
+const Line = function(opts) {
   var line = document.createElementNS(svgns, 'line');
   return setAttr(line,opts);
 };
 
-var Polygon = function(opts) {
+const Polygon = function(opts) {
   var line = document.createElementNS(svgns, 'polygon');
   return setAttr(line,opts);
 };
 
-module.exports.rect = Rect;
-module.exports.line = Line;
-module.exports.polygon = Polygon;
-module.exports.base = Base;
+export {Base as base, Line as line,
+  Rect as rect, Polygon as polygon};

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,8 +1,7 @@
-var treeHelper;
-var _ = require("underscore");
-var SeqCollection = require("../model/SeqCollection");
+const _ = require("underscore");
+import SeqCollection from "../model/SeqCollection";
 
-module.exports = treeHelper =  function(msa) {
+const TreeHelper =  function(msa) {
   this.msa = msa;
   return this;
 };
@@ -72,4 +71,5 @@ var tf =
     }
     };
 
-_.extend(treeHelper.prototype , tf);
+_.extend(TreeHelper.prototype , tf);
+export default TreeHelper;

--- a/src/views/AlignmentBody.js
+++ b/src/views/AlignmentBody.js
@@ -1,8 +1,8 @@
-var boneView = require("backbone-childs");
-var SeqBlock = require("./canvas/CanvasSeqBlock");
-var LabelBlock = require("./labels/LabelBlock");
+const boneView = require("backbone-childs");
+import SeqBlock from "./canvas/CanvasSeqBlock";
+import LabelBlock from "./labels/LabelBlock";
 
-module.exports = boneView.extend({
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -56,3 +56,4 @@ module.exports = boneView.extend({
     return width;
   }
 });
+export default View;

--- a/src/views/OverviewBox.js
+++ b/src/views/OverviewBox.js
@@ -1,11 +1,10 @@
-var OverviewBox;
-var view = require("backbone-viewj");
-var mouse = require("mouse-pos");
-var selection = require("../g/selection/Selection");
-var jbone = require("jbone");
-var _ = require("underscore");
+const view = require("backbone-viewj");
+const mouse = require("mouse-pos");
+const jbone = require("jbone");
+const _ = require("underscore");
+import selection from "../g/selection/Selection";
 
-module.exports = OverviewBox = view.extend({
+const OverviewBox = view.extend({
 
   className: "biojs_msa_overviewbox",
   tagName: "canvas",
@@ -250,3 +249,4 @@ module.exports = OverviewBox = view.extend({
     return this.el.style.cursor = "crosshair";
   }
 });
+export default OverviewBox;

--- a/src/views/Search.js
+++ b/src/views/Search.js
@@ -1,12 +1,12 @@
-var boneView = require("backbone-childs");
-var _ = require('underscore');
-var k = require('koala-js');
-var dom = require('dom-helper');
-var sel = require("../g/selection/Selection");
+const boneView = require("backbone-childs");
+const _ = require('underscore');
+const k = require('koala-js');
+const dom = require('dom-helper');
+import sel from "../g/selection/Selection";
 
 // this is a very simplistic approach to show search result
 // TODO: needs proper styling
-module.exports = boneView.extend({
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -129,3 +129,4 @@ module.exports = boneView.extend({
     return this.sel = newSeli;
   }
 });
+export default View;

--- a/src/views/Stage.js
+++ b/src/views/Stage.js
@@ -1,12 +1,13 @@
-var boneView = require("backbone-childs");
-var AlignmentBody = require("./AlignmentBody");
-var HeaderBlock = require("./header/HeaderBlock");
-var OverviewBox = require("./OverviewBox");
-var Search = require("./Search");
-var _ = require('underscore');
+const boneView = require("backbone-childs");
+const _ = require('underscore');
+
+import AlignmentBody from "./AlignmentBody";
+import HeaderBlock from "./header/HeaderBlock";
+import OverviewBox from "./OverviewBox";
+import Search from "./Search";
 
 // a neat collection view
-module.exports = boneView.extend({
+const View  = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -71,3 +72,4 @@ module.exports = boneView.extend({
     }
   }
 });
+export default View;

--- a/src/views/canvas/CanvasCharCache.js
+++ b/src/views/canvas/CanvasCharCache.js
@@ -1,6 +1,6 @@
-var Events = require("biojs-events");
+const Events = require("biojs-events");
 
-module.exports = class CanvasCharCache {
+class CanvasCharCache {
 
   constructor(g) {
     this.g = g;
@@ -41,3 +41,4 @@ module.exports = class CanvasCharCache {
     return this.ctx.fillText(letter,width / 2,height / 2,width);
   }
 };
+export default CanvasCharCache;

--- a/src/views/canvas/CanvasCoordsCache.js
+++ b/src/views/canvas/CanvasCoordsCache.js
@@ -1,6 +1,5 @@
-var cacheConstructor;
-var _ = require("underscore");
-var Events = require("biojs-events");
+const _ = require("underscore");
+const Events = require("biojs-events");
 
 var cache =
 
@@ -13,7 +12,7 @@ var cache =
   }
   };
 
-module.exports = cacheConstructor = function(g,model) {
+const CacheConstructor = function(g,model) {
   this.g = g;
   this.model = model;
   this.maxScrollWidth = 0;
@@ -33,5 +32,6 @@ module.exports = cacheConstructor = function(g,model) {
   return this;
 };
 
-_.extend(cacheConstructor.prototype, cache);
-Events.mixin(cacheConstructor.prototype);
+_.extend(CacheConstructor.prototype, cache);
+Events.mixin(CacheConstructor.prototype);
+export default CacheConstructor;

--- a/src/views/canvas/CanvasSelection.js
+++ b/src/views/canvas/CanvasSelection.js
@@ -1,14 +1,13 @@
-var SelectionClass;
-var _ = require("underscore");
+const _ = require("underscore");
 
-module.exports = SelectionClass = (function(g,ctx) {
+const CanvasSelection = (function(g,ctx) {
   this.g = g;
   this.ctx = ctx;
   return this;
 }
 );
 
-_.extend(SelectionClass.prototype, {
+_.extend(CanvasSelection.prototype, {
 
   // TODO: should I be moved to the selection manager?
   // returns an array with the currently selected residues
@@ -156,3 +155,4 @@ _.extend(SelectionClass.prototype, {
     return [mPrevSel,mNextSel];
   }
 });
+export default CanvasSelection;

--- a/src/views/canvas/CanvasSeqBlock.js
+++ b/src/views/canvas/CanvasSeqBlock.js
@@ -1,13 +1,14 @@
-var boneView = require("backbone-childs");
-var mouse = require("mouse-pos");
-var _ = require("underscore");
-var jbone = require("jbone");
-var CharCache = require("./CanvasCharCache");
-var SelectionClass = require("./CanvasSelection");
-var CanvasSeqDrawer = require("./CanvasSeqDrawer");
-var CanvasCoordsCache = require("./CanvasCoordsCache");
+const boneView = require("backbone-childs");
+const mouse = require("mouse-pos");
+const _ = require("underscore");
+const jbone = require("jbone");
 
-module.exports = boneView.extend({
+import CharCache from "./CanvasCharCache";
+import SelectionClass from "./CanvasSelection";
+import CanvasSeqDrawer from "./CanvasSeqDrawer";
+import CanvasCoordsCache from "./CanvasCoordsCache";
+
+const View = boneView.extend({
 
   tagName: "canvas",
 
@@ -388,3 +389,4 @@ module.exports = boneView.extend({
     return scrollObj;
   }
 });
+export default View;

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -1,7 +1,6 @@
-var construc;
-var _ = require("underscore");
+const _ = require("underscore");
 
-var drawer =
+const Drawer =
 
   {drawLetters: function() {
 
@@ -148,7 +147,7 @@ var drawer =
   };
 
 
-module.exports = construc = function(g,ctx,model,opts) {
+const CanvasSeqDrawer = function(g,ctx,model,opts) {
   this.g = g;
   this.ctx = ctx;
   this.model = model;
@@ -161,4 +160,5 @@ module.exports = construc = function(g,ctx,model,opts) {
   return this;
 };
 
-_.extend(construc.prototype, drawer);
+_.extend(CanvasSeqDrawer.prototype, Drawer);
+export default CanvasSeqDrawer;

--- a/src/views/header/ConservationView.js
+++ b/src/views/header/ConservationView.js
@@ -1,8 +1,8 @@
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
-var svg = require("../../utils/svg");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
+import * as svg from "../../utils/svg";
 
-var ConservationView = view.extend({
+const ConservationView = view.extend({
 
   className: "biojs_msa_conserv",
 
@@ -100,4 +100,4 @@ var ConservationView = view.extend({
   }
 });
 
-module.exports = ConservationView;
+export default ConservationView;

--- a/src/views/header/GapView.js
+++ b/src/views/header/GapView.js
@@ -1,9 +1,9 @@
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
-var svg = require("../../utils/svg");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
+import * as svg from "../../utils/svg";
 
 // TODO: merge this with the conservation view
-var ConservationView = view.extend({
+const ConservationView = view.extend({
 
   className: "biojs_msa_gapview",
 
@@ -100,4 +100,4 @@ var ConservationView = view.extend({
   }
 });
 
-module.exports = ConservationView;
+export default ConservationView;

--- a/src/views/header/HeaderBlock.js
+++ b/src/views/header/HeaderBlock.js
@@ -1,8 +1,8 @@
-var boneView = require("backbone-childs");
-var LabelHeader = require("./LabelHeader");
-var RightLabelHeader = require("./RightHeaderBlock");
+const boneView = require("backbone-childs");
+import LabelHeader from "./LabelHeader";
+import RightLabelHeader from "./RightHeaderBlock";
 
-module.exports = boneView.extend({
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -33,3 +33,4 @@ module.exports = boneView.extend({
     return this.el.className = "biojs_msa_header";
   }
 });
+export default View;

--- a/src/views/header/LabelHeader.js
+++ b/src/views/header/LabelHeader.js
@@ -1,9 +1,8 @@
-var LabelHeader;
-var k = require("koala-js");
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
+const k = require("koala-js");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
 
-module.exports = LabelHeader = view.extend({
+const LabelHeader = view.extend({
 
   className: "biojs_msa_headers",
 
@@ -88,3 +87,4 @@ module.exports = LabelHeader = view.extend({
     return metaHeader;
   }
 });
+export default LabelHeader;

--- a/src/views/header/MarkerView.js
+++ b/src/views/header/MarkerView.js
@@ -1,9 +1,9 @@
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
-var svg = require("../../utils/svg");
-var jbone = require("jbone");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
+const jbone = require("jbone");
+import * as svg from "../../utils/svg";
 
-var HeaderView = view.extend({
+const MarkerView = view.extend({
 
   className: "biojs_msa_marker",
 
@@ -125,4 +125,4 @@ var HeaderView = view.extend({
   }
 });
 
-module.exports = HeaderView;
+export default MarkerView;

--- a/src/views/header/RightHeaderBlock.js
+++ b/src/views/header/RightHeaderBlock.js
@@ -1,11 +1,12 @@
-var MarkerView = require("./MarkerView");
-var ConservationView = require("./ConservationView");
-var boneView = require("backbone-childs");
-var _ = require('underscore');
-var SeqLogoWrapper = require("./SeqLogoWrapper");
-var GapView = require("./GapView");
+const boneView = require("backbone-childs");
+const _ = require('underscore');
 
-module.exports = boneView.extend({
+import MarkerView from "./MarkerView";
+import ConservationView from "./ConservationView";
+import SeqLogoWrapper from "./SeqLogoWrapper";
+import GapView from "./GapView";
+
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -108,3 +109,4 @@ module.exports = boneView.extend({
     return this.el.style.width = this.g.zoomer.getAlignmentWidth() + "px";
   }
 });
+export default View;

--- a/src/views/header/SeqLogoWrapper.js
+++ b/src/views/header/SeqLogoWrapper.js
@@ -1,9 +1,9 @@
-var SeqLogoView = require("biojs-vis-seqlogo/light");
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
+const SeqLogoView = require("biojs-vis-seqlogo/light");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
 
 // this is a bridge between the MSA and the seqlogo viewer
-module.exports = view.extend({
+const SeqLogoWrapper = view.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -54,3 +54,4 @@ module.exports = view.extend({
     return this.seqlogo.render();
   }
 });
+export default SeqLogoWrapper;

--- a/src/views/labels/LabelBlock.js
+++ b/src/views/labels/LabelBlock.js
@@ -1,7 +1,7 @@
-var LabelRowView = require("./LabelRowView");
-var boneView = require("backbone-childs");
+const boneView = require("backbone-childs");
+import LabelRowView from "./LabelRowView";
 
-module.exports = boneView.extend({
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -60,3 +60,4 @@ module.exports = boneView.extend({
     return this.el.style.height = this.g.zoomer.get("alignmentHeight") + "px";
   }
 });
+export default View;

--- a/src/views/labels/LabelRowView.js
+++ b/src/views/labels/LabelRowView.js
@@ -1,8 +1,8 @@
-var boneView = require("backbone-childs");
-var LabelView = require("./LabelView");
-var MetaView = require("./MetaView");
+const boneView = require("backbone-childs");
+import LabelView from "./LabelView";
+import MetaView from "./MetaView";
 
-module.exports = boneView.extend({
+const View = boneView.extend({
 
   initialize: function(data) {
     this.g = data.g;
@@ -52,3 +52,4 @@ module.exports = boneView.extend({
     }
   }
 });
+export default View;

--- a/src/views/labels/LabelView.js
+++ b/src/views/labels/LabelView.js
@@ -1,7 +1,7 @@
-var view = require("backbone-viewj");
-var dom = require("dom-helper");
+const view = require("backbone-viewj");
+const dom = require("dom-helper");
 
-var LabelView = view.extend({
+const LabelView = view.extend({
 
   initialize: function(data) {
     this.seq = data.seq;
@@ -97,4 +97,4 @@ var LabelView = view.extend({
   }
 });
 
-module.exports = LabelView;
+export default LabelView;

--- a/src/views/labels/MetaView.js
+++ b/src/views/labels/MetaView.js
@@ -1,11 +1,10 @@
-var MetaView;
-var view = require("backbone-viewj");
-var MenuBuilder = require("../../menu/menubuilder");
-var _ = require('underscore');
-var dom = require("dom-helper");
-var st = require("msa-seqtools");
+const view = require("backbone-viewj");
+const _ = require('underscore');
+const dom = require("dom-helper");
+const st = require("msa-seqtools");
+import MenuBuilder from "../../menu/menubuilder";
 
-module.exports = MetaView = view.extend({
+const MetaView = view.extend({
 
   className: "biojs_msa_metaview",
 
@@ -104,3 +103,4 @@ module.exports = MetaView = view.extend({
     return this.g.trigger("meta:mouseout", {seqId: this.model.get("id", {evt:evt})});
   }
 });
+export default MetaView;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,7 @@ module.exports = {
     module: {
         loaders: [
             {   test: path.join(__dirname, 'src'),
-                loader: 'babel-loader',
-                query: {
-                    presets: 'es2015',
-                },
+                loader: 'babel-loader'
             },
             { test: /\.css$/,
                 loader: "style-loader!css-loader" }


### PR DESCRIPTION
Since we use es6 for quite some time, I thought it would be cool to use ES6 imports.

Note: this doesn't shouldn't change anything, but should make it easy

1) to switch to TypeScript (if we want to)
2) to use partial exports e.g imports extends from "underscore"

For a quick intro have a look here:
http://exploringjs.com/es6/ch_modules.html
https://github.com/ModuleLoader/es6-module-loader/wiki/Brief-Overview-of-ES6-Module-syntax