### PR TITLE
add controls to zoom in/out

### DIFF
--- a/css/msa.css
+++ b/css/msa.css
@@ -1,8 +1,13 @@
 /* BASIC */
 
+.biojs_msa_div {
+  
+}
+
 .biojs_msa_stage {
     cursor: default;
     line-height: normal; 
+    font-family: Helvetica;
 }
 
 .biojs_msa_seqblock {

--- a/css/msa.css
+++ b/css/msa.css
@@ -162,3 +162,22 @@
 }
 
 /* END Menubar */
+
+.biojs_msa_scale {
+  width: 300px;
+  margin: 5px 0 0 auto;
+  padding: 5px;
+  text-align: center;
+}
+.biojs_msa_scale .msa-btngroup {
+  margin: 5px auto 0;
+}
+.biojs_msa_scale .msa-btn {
+  font-size: 1.3em;
+  display: inline-block;
+  padding: 2px 8px;
+  margin-bottom: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-sizing: border-box;
+}

--- a/css/msa.css
+++ b/css/msa.css
@@ -63,14 +63,19 @@
 /* END BASIC */
 /* Marker */
 
-.biojs_msa_marker{
-    color:grey;
-    white-space: nowrap;
-    cursor: pointer;
+.biojs_msa_marker {
+  color: #999;
+  white-space: nowrap;
 }
 
-.biojs_msa_marker span{
-    text-align: center;
+.biojs_msa_marker .msa-col-header {
+  cursor: pointer;
+  cursor: pointer;
+  text-align: center;
+}
+
+.biojs_msa_marker .msa-col-header:hover {
+  color: #f00;
 }
 
 /* END Marker */
@@ -168,8 +173,17 @@
 
 /* END Menubar */
 
+.biojs_msa_div {
+  position: relative;
+}
+
 .biojs_msa_scale {
-  width: 300px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background-color: #fff;
+  box-shadow: 0 2px 3px #999;
+  border-radius: 3px;
   margin: 5px 0 0 auto;
   padding: 5px;
   text-align: center;
@@ -177,8 +191,12 @@
 .biojs_msa_scale .msa-btngroup {
   margin: 5px auto 0;
 }
+.biojs_msa_scale [type="range"] {
+  cursor: pointer;
+}
 .biojs_msa_scale .msa-btn {
-  font-size: 1.3em;
+  cursor: pointer;
+  font-size: 1.1em;
   display: inline-block;
   padding: 2px 8px;
   margin-bottom: 0;

--- a/css/msa.css
+++ b/css/msa.css
@@ -194,7 +194,25 @@
 .biojs_msa_scale [type="range"] {
   cursor: pointer;
 }
-.biojs_msa_scale .msa-btn {
+
+.biojs_msa_scale .msa-scale-minimised {
+}
+.biojs_msa_scale .msa-scale-minimised {
+}
+.biojs_msa_scale .msa-btn-close {
+  text-align: right;
+  font-size: 0.8em;
+  padding: 2px;
+}
+.biojs_msa_scale .msa-btn-open {
+  background-color: #fff;
+}
+
+.biojs_msa_scale .msa-hide {
+  display: none;
+}
+
+.msa-btn {
   cursor: pointer;
   font-size: 1.1em;
   display: inline-block;
@@ -203,4 +221,7 @@
   border: 1px solid transparent;
   border-radius: 4px;
   box-sizing: border-box;
+}
+.msa-btn:hover {
+  background-color: #ddd;
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dom-helper": "^1.0.0",
     "jbone": "^1.1.2",
     "koala-js": "^1.0.7",
+    "linear-scale": "0.0.1",
     "menu-builder": "^0.0.7",
     "mouse-pos": "^1.0.3",
     "msa-colorschemes": "^1.0.8",

--- a/snippets/scale.js
+++ b/snippets/scale.js
@@ -1,0 +1,12 @@
+/* global rootDiv */
+var msa = window.msa;
+var opts = {
+  el: rootDiv,
+  importURL: "./data/fer1.clustal",
+  bootstrapMenu: true, // simplified behavior to add the menu bar, you can also create your own menu instance
+  vis: {
+    scaleslider: true
+  }
+};
+var m = new msa(opts);
+//@biojs-instance=m.g

--- a/src/g/StageScale.js
+++ b/src/g/StageScale.js
@@ -13,19 +13,36 @@ module.exports = StageScale = Model.extend({
   
   defaults: {
     // general
-    currentSize: 3,
+    currentSize: 4,
     step: 1,
-    sizeRange: [1, 5],
-    columnWidthRange: [5, 50],
-    originalSize: 3,
+    originalSize: false,
+    scaleBy: 'category',
+    columnWidthCategories: [ 3, 5, 8, 12, 20, 30 ],
+    sizeRange: [ 1, 5 ],
+    columnWidthRange: [ 3, 40 ],
   },
 
   initialize: function(args) {
     var params = _.extend({}, this.defaults, args);
-    this.sizeRange = params.sizeRange;
     this.set('originalSize', params.currentSize);
-    this.columnWidthRange = params.columnWidthRange;
-    this.scale = LinearScale().domain(this.sizeRange).range(this.columnWidthRange);
+    this.columnWidthCategories = [ 3, 5, 7, 10, 20, 30 ];
+    
+    var sizeRange, columnWidthRange, scale;
+    if ( params.scaleBy == 'category' ) {
+      var categories = params.columnWidthCategories;
+      sizeRange = [ 1, categories.length ];
+      columnWidthRange = [ _.first( categories ), _.last( categories ) ];
+      scale = function (size) { return categories[size - 1] };
+    }
+    else {
+      sizeRange = params.sizeRange;
+      columnWidthRange = params.columnWidthRange;
+      scale = LinearScale().domain(this.sizeRange).range(this.columnWidthRange);
+    }
+    this.sizeRange = sizeRange;
+    this.columnWidthRange = columnWidthRange;
+    this.scale = scale;
+
     this.setSize( params.currentSize );
     return this;
   },
@@ -51,11 +68,10 @@ module.exports = StageScale = Model.extend({
   
   setSize: function(size) {
     size = parseInt(size);
-
-    var size = size < this.sizeRange[0] ? this.sizeRange[0]
-             : size > this.sizeRange[1] ? this.sizeRange[1]
-             : size;
-
+    size = size < this.sizeRange[0] ? this.sizeRange[0]
+         : size > this.sizeRange[1] ? this.sizeRange[1]
+         : size;
+         
     this.set( 'currentSize', size );
     console.log( "setSize", size, this.getColumnWidth() );
     return this;

--- a/src/g/StageScale.js
+++ b/src/g/StageScale.js
@@ -1,0 +1,69 @@
+var StageScale;
+var Model = require("backbone-thin").Model;
+var LinearScale = require("linear-scale");
+
+// pixel properties for some components
+module.exports = StageScale = Model.extend({
+
+  constructor: function(attributes,options) {
+    Model.apply(this, arguments);
+    this.g = options.g;
+    return this;
+  },
+  
+  defaults: {
+    // general
+    currentSize: 3,
+    step: 1,
+    sizeRange: [1, 5],
+    columnWidthRange: [5, 50],
+    originalSize: 3,
+  },
+
+  initialize: function(args) {
+    var params = _.extend({}, this.defaults, args);
+    this.sizeRange = params.sizeRange;
+    this.set('originalSize', params.currentSize);
+    this.columnWidthRange = params.columnWidthRange;
+    this.scale = LinearScale().domain(this.sizeRange).range(this.columnWidthRange);
+    this.setSize( params.currentSize );
+    return this;
+  },
+  
+  getColumnWidth: function() {
+    var s = this.getSize();
+    var w = this.scale(s);
+    //console.log( "getColumnWidth", "scale", this.scale, "size", s, "width: ", w);
+    return w;
+  },
+  
+  bigger: function(){
+    return this.setSize( this.get('currentSize') + this.get('step') );
+  },
+  
+  smaller: function(){
+    return this.setSize( this.get('currentSize') - this.get('step') );
+  },
+  
+  reset: function() {
+    return this.setSize( this.get('originalSize') );
+  },
+  
+  setSize: function(size) {
+    size = parseInt(size);
+
+    var size = size < this.sizeRange[0] ? this.sizeRange[0]
+             : size > this.sizeRange[1] ? this.sizeRange[1]
+             : size;
+
+    this.set( 'currentSize', size );
+    console.log( "setSize", size, this.getColumnWidth() );
+    return this;
+  },
+  
+  getSize: function() {
+    return this.get('currentSize');    
+  },
+  
+});
+

--- a/src/g/StageScale.js
+++ b/src/g/StageScale.js
@@ -6,52 +6,38 @@ var LinearScale = require("linear-scale");
 module.exports = StageScale = Model.extend({
 
   constructor: function(attributes,options) {
-    Model.apply(this, arguments);
     this.g = options.g;
+    Model.apply(this, arguments);
     return this;
   },
   
   defaults: {
     // general
-    currentSize: 4,
+    currentSize: 5,
     step: 1,
     originalSize: false,
-    scaleBy: 'category',
-    columnWidthCategories: [ 3, 5, 8, 12, 20, 30 ],
-    sizeRange: [ 1, 5 ],
-    columnWidthRange: [ 3, 40 ],
+    scaleCategories: [ 
+      { columnWidth: 1, markerStepSize: 20, stepSize: 0 },
+      { columnWidth: 3, markerStepSize: 20, stepSize: 0 },
+      { columnWidth: 5, markerStepSize: 10, stepSize: 0 },
+      { columnWidth: 9, markerStepSize: 5, stepSize: 1 },
+      { columnWidth: 13, markerStepSize: 5, stepSize: 1 },
+      { columnWidth: 20, markerStepSize: 1, stepSize: 1 },
+      { columnWidth: 30, markerStepSize: 1, stepSize: 1 },
+    ],
   },
 
   initialize: function(args) {
-    var params = _.extend({}, this.defaults, args);
-    this.set('originalSize', params.currentSize);
-    this.columnWidthCategories = [ 3, 5, 7, 10, 20, 30 ];
     
-    var sizeRange, columnWidthRange, scale;
-    if ( params.scaleBy == 'category' ) {
-      var categories = params.columnWidthCategories;
-      sizeRange = [ 1, categories.length ];
-      columnWidthRange = [ _.first( categories ), _.last( categories ) ];
-      scale = function (size) { return categories[size - 1] };
-    }
-    else {
-      sizeRange = params.sizeRange;
-      columnWidthRange = params.columnWidthRange;
-      scale = LinearScale().domain(this.sizeRange).range(this.columnWidthRange);
-    }
-    this.sizeRange = sizeRange;
-    this.columnWidthRange = columnWidthRange;
-    this.scale = scale;
+    var currentSize = this.get('currentSize');    
+    this.set('originalSize', currentSize);
+    this.setSize( currentSize );
 
-    this.setSize( params.currentSize );
     return this;
   },
   
-  getColumnWidth: function() {
-    var s = this.getSize();
-    var w = this.scale(s);
-    //console.log( "getColumnWidth", "scale", this.scale, "size", s, "width: ", w);
-    return w;
+  getSizeRange() {
+    return [ 1, this.get('scaleCategories').length ];
   },
   
   bigger: function(){
@@ -67,18 +53,33 @@ module.exports = StageScale = Model.extend({
   },
   
   setSize: function(size) {
+    var range = this.getSizeRange();
     size = parseInt(size);
-    size = size < this.sizeRange[0] ? this.sizeRange[0]
-         : size > this.sizeRange[1] ? this.sizeRange[1]
+    size = size < range[0] ? range[0]
+         : size > range[1] ? range[1]
          : size;
-         
-    this.set( 'currentSize', size );
-    console.log( "setSize", size, this.getColumnWidth() );
+    
+    this.set('currentSize', size);    
     return this;
   },
   
   getSize: function() {
-    return this.get('currentSize');    
+    return this.get('currentSize');
+  },
+
+  getColumnWidth: function() {
+    return this.getScaleInfo().columnWidth;
+  },
+    
+  getScaleInfo: function() {
+    var size = this.getSize();
+    var categories = this.get('scaleCategories');
+    if ( size > 0 && size <= categories.length ) {
+      return categories[size-1];
+    }
+    else {
+      console.error( "out of bounds" );
+    }
   },
   
 });

--- a/src/g/visOrdering.js
+++ b/src/g/visOrdering.js
@@ -10,6 +10,7 @@ module.exports = Visibility = Model.extend({
     {searchBox: -10,
     overviewBox: 30,
     headerBox: -1,
-    alignmentBody: 0
+    alignmentBody: 0,
+    scaleSlider: 50
     }
 });

--- a/src/g/visibility.js
+++ b/src/g/visibility.js
@@ -12,6 +12,7 @@ module.exports = Visibility = Model.extend({
     seqlogo: false,
     gapHeader: false,
     leftHeader: true,
+    scaleslider: false,
 
     // about the labels
     labels: true,

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -68,10 +68,11 @@ module.exports = Zoomer = Model.extend({
   calcDefaults: function(model) {
     var maxLen = model.getMaxLength();
     if (maxLen < 200 && model.length < 30) {
-      return this.defaults.boxRectWidth = this.defaults.boxRectHeight = 5;
+      this.defaults.boxRectWidth = this.defaults.boxRectHeight = 5;
     }
+    return this;
   },
-
+    
   // @param n [int] maxLength of all seqs
   getAlignmentWidth: function(n) {
     if (this.get("autoResize") && n !== undefined) {

--- a/src/menu/views/VisMenu.js
+++ b/src/menu/views/VisMenu.js
@@ -71,6 +71,7 @@ const VisMenu = MenuBuilder.extend({
     vis.push({name: "sequence logo", id: "seqlogo"});
     vis.push({name: "gap weights", id: "gapHeader"});
     vis.push({name: "conservation weights", id: "conserv"});
+    vis.push({name: "scale slider", id: "scaleslider"});
     //vis.push name: "Left header", id: "leftHeader"
     vis.push({name: "Label", id: "labelName"});
     vis.push({name: "ID", id: "labelId"});

--- a/src/msa.js
+++ b/src/msa.js
@@ -66,7 +66,7 @@ const MSA = boneView.extend({
     this.g.visorder = new VisOrdering(data.visorder);
     this.g.zoomer = new Zoomer(data.zoomer,{g:this.g, model: this.seqs});
     
-    this.g.scale = new StageScale(data.scale, this.g);
+    this.g.scale = new StageScale(data.scale, {g: this.g});
     
     // store config options for plugins
     this.g.conservationConfig = data.conserv;

--- a/src/msa.js
+++ b/src/msa.js
@@ -12,6 +12,8 @@ import Visibility from "./g/visibility";
 import VisOrdering from "./g/visOrdering";
 import Zoomer from "./g/zoomer";
 
+import StageScale from "./g/StageScale";
+
 // MV from backbone
 const boneView = require("backbone-childs");
 const Eventhandler = require("biojs-events");
@@ -47,13 +49,14 @@ const MSA = boneView.extend({
     if (!(data.visorder != null)) { data.visorder = {}; }
     if (!(data.zoomer != null)) { data.zoomer = {}; }
     if (!(data.conserv != null)) { data.conserv = {}; }
+    if (!(data.scale != null)) { data.scale = {}; }
 
     // g is our global Mediator
     this.g = Eventhandler.mixin({});
 
     // load seqs and add subviews
     this.seqs = this.g.seqs = new SeqCollection(data.seqs, this.g);
-
+        
     // populate it and init the global models
     this.g.config = new Config(data.conf);
     this.g.package = new Package(this.g);
@@ -62,6 +65,8 @@ const MSA = boneView.extend({
     this.g.vis = new Visibility(data.vis, {model: this.seqs});
     this.g.visorder = new VisOrdering(data.visorder);
     this.g.zoomer = new Zoomer(data.zoomer,{g:this.g, model: this.seqs});
+    
+    this.g.scale = new StageScale(data.scale, this.g);
     
     // store config options for plugins
     this.g.conservationConfig = data.conserv;

--- a/src/views/AlignmentBody.js
+++ b/src/views/AlignmentBody.js
@@ -21,10 +21,12 @@ const View = boneView.extend({
 
     this.listenTo(this.g.zoomer, "change:alignmentHeight", this.adjustHeight);
     this.listenTo(this.g.zoomer, "change:alignmentWidth", this.adjustWidth);
-    return this.listenTo(this.g.columns, "change:hidden", this.adjustHeight);
+    this.listenTo(this.g.columns, "change:hidden", this.adjustHeight);
+    return this;
   },
 
   render: function() {
+    console.log("AlignmentBody.render()");
     this.renderSubviews();
     this.el.className = "biojs_msa_albody";
     this.el.style.whiteSpace = "nowrap";

--- a/src/views/AlignmentBody.js
+++ b/src/views/AlignmentBody.js
@@ -26,7 +26,6 @@ const View = boneView.extend({
   },
 
   render: function() {
-    console.log("AlignmentBody.render()");
     this.renderSubviews();
     this.el.className = "biojs_msa_albody";
     this.el.style.whiteSpace = "nowrap";

--- a/src/views/ScaleSlider.js
+++ b/src/views/ScaleSlider.js
@@ -1,0 +1,80 @@
+const BoneView = require("backbone-viewj");
+const _ = require("underscore");
+const $ = require("jbone");
+//const Slider = require("bootstrap-slider");
+
+const View = BoneView.extend({
+
+  initialize: function(data) {
+    this.g = data.g;
+    this.listenTo(this.g.zoomer,"change:columnWidth", this.render);
+    return this;
+  },
+  
+  attributes: {
+    class: "biojs_msa_scale"
+  },
+  
+  events: {
+    'change input': 'updateSlider',
+    'click button': 'clickButton',
+  },
+  
+  template: _.template('\
+<input type="range" \
+  data-provide="slider" \
+  min="<%= min %>" \
+  max="<%= max %>" \
+  step="<%= step %>" \
+  value="<%= value %>" \
+>\
+<div class="btngroup msa-btngroup">\
+<button class="btn msa-btn" data-action="smaller"><span class="glyphicon-zoom-out"></span>-</button>\
+<button class="btn msa-btn" data-action="bigger"><span class="glyphicon-zoom-in"></span>+</button>\
+<button class="btn msa-btn" data-action="reset"><span class="glyphicon-repeat"></span>reset</button>\
+</div>\
+'),
+  
+  render: function() {
+    var sizeRange = this.model.sizeRange;
+    var stash = {
+      value: this.model.getSize(),
+      min: sizeRange[0],
+      max: sizeRange[1],
+      step: this.model.step || 1,
+      colWidth: this.model.getColumnWidth(),
+    };
+    this.$el.html( this.template(stash) );
+    return this;
+  },
+
+  updateSlider: function(e) {
+    console.log("ScaleSlider.updateSlider", e);
+    var target = e.target;
+    var size = parseInt( $(target).val() );
+    //console.log( "updateSize", size );
+    this.model.setSize(size);
+    this.syncModel();
+  },
+
+  clickButton: function(e) {
+    console.log("ScaleSlider.clickButton", e);
+    var target = e.target;
+    var action = $(target).data('action');
+    var method = this.model[action];
+    // bigger, smaller, reset
+    if( typeof this.model[action] === 'function' ) {
+      this.model[action]();
+      this.syncModel();
+    }
+    return this;
+  },
+  
+  syncModel: function() {
+    console.log("ScaleSlider.syncModel");
+    var colWidth = this.model.getColumnWidth();
+    this.g.zoomer.set('columnWidth', colWidth );
+  }
+  
+});
+export default View;

--- a/src/views/ScaleSlider.js
+++ b/src/views/ScaleSlider.js
@@ -8,6 +8,7 @@ const View = BoneView.extend({
   initialize: function(data) {
     this.g = data.g;
     this.listenTo(this.g.zoomer,"change:columnWidth", this.render);
+    this.toggleClass = 'msa-hide';
     return this;
   },
   
@@ -17,26 +18,34 @@ const View = BoneView.extend({
   
   events: {
     'change input': 'updateSlider',
-    'click button': 'clickButton',
+    'click button.msa-btn-close': 'hide',
+    'click button.msa-btn-open': 'show',
+    'click button[data-action]': 'clickButton',
   },
   
   template: _.template('\
-<input type="range" \
-  data-provide="slider" \
-  min="<%= min %>" \
-  max="<%= max %>" \
-  step="<%= step %>" \
-  value="<%= value %>" \
->\
-<div class="btngroup msa-btngroup">\
-<button class="btn msa-btn" data-action="smaller"><span class="glyphicon-zoom-out"></span>-</button>\
-<button class="btn msa-btn" data-action="bigger"><span class="glyphicon-zoom-in"></span>+</button>\
-<button class="btn msa-btn" data-action="reset"><span class="glyphicon-repeat"></span>reset</button>\
+<div class="msa-scale-minimised">\
+  <button class="btn msa-btn msa-btn-open">Zoom</button>\
+</div>\
+<div class="msa-scale-maximised">\
+  <button class="btn msa-btn msa-btn-close" style="float:right">&times; close</button>\
+  <input type="range" \
+    data-provide="slider" \
+    min="<%= min %>" \
+    max="<%= max %>" \
+    step="<%= step %>" \
+    value="<%= value %>" \
+  >\
+  <div class="btngroup msa-btngroup">\
+    <button class="btn msa-btn" data-action="smaller"><span class="glyphicon-zoom-out"></span>-</button>\
+    <button class="btn msa-btn" data-action="bigger"><span class="glyphicon-zoom-in"></span>+</button>\
+    <button class="btn msa-btn" data-action="reset"><span class="glyphicon-repeat"></span>reset</button>\
+  </div>\
 </div>\
 '),
   
   render: function() {
-    var sizeRange = this.model.sizeRange;
+    var sizeRange = this.model.getSizeRange();
     var stash = {
       value: this.model.getSize(),
       min: sizeRange[0],
@@ -45,11 +54,11 @@ const View = BoneView.extend({
       colWidth: this.model.getColumnWidth(),
     };
     this.$el.html( this.template(stash) );
+    this.hide();    
     return this;
   },
 
   updateSlider: function(e) {
-    console.log("ScaleSlider.updateSlider", e);
     var target = e.target;
     var size = parseInt( $(target).val() );
     //console.log( "updateSize", size );
@@ -58,7 +67,7 @@ const View = BoneView.extend({
   },
 
   clickButton: function(e) {
-    console.log("ScaleSlider.clickButton", e);
+    console.log( "clickButton", this, e );
     var target = e.target;
     var action = $(target).data('action');
     var method = this.model[action];
@@ -70,11 +79,22 @@ const View = BoneView.extend({
     return this;
   },
   
+  hide: function() {
+    this.$el.find(".msa-scale-minimised").removeClass(this.toggleClass);
+    this.$el.find(".msa-scale-maximised").addClass(this.toggleClass);
+  },
+
+  show: function() {
+    this.$el.find(".msa-scale-minimised").addClass(this.toggleClass);
+    this.$el.find(".msa-scale-maximised").removeClass(this.toggleClass);
+  },
+  
   syncModel: function() {
-    console.log("ScaleSlider.syncModel");
-    var colWidth = this.model.getColumnWidth();
-    this.g.zoomer.set('columnWidth', colWidth );
-  }
+    var info = this.model.getScaleInfo();
+    this.g.zoomer.set('columnWidth', info.columnWidth );
+    this.g.zoomer.set('stepSize', info.stepSize );
+    this.g.zoomer.set('markerStepSize', info.markerStepSize );
+  },
   
 });
 export default View;

--- a/src/views/ScaleSlider.js
+++ b/src/views/ScaleSlider.js
@@ -5,10 +5,12 @@ const $ = require("jbone");
 
 const View = BoneView.extend({
 
+  
   initialize: function(data) {
     this.g = data.g;
     this.listenTo(this.g.zoomer,"change:columnWidth", this.render);
     this.toggleClass = 'msa-hide';
+    this.isVisible = true;
     return this;
   },
   
@@ -29,6 +31,7 @@ const View = BoneView.extend({
 </div>\
 <div class="msa-scale-maximised">\
   <button class="btn msa-btn msa-btn-close" style="float:right">&times; close</button>\
+  <div>\
   <input type="range" \
     data-provide="slider" \
     min="<%= min %>" \
@@ -36,6 +39,7 @@ const View = BoneView.extend({
     step="<%= step %>" \
     value="<%= value %>" \
   >\
+  </div>\
   <div class="btngroup msa-btngroup">\
     <button class="btn msa-btn" data-action="smaller"><span class="glyphicon-zoom-out"></span>-</button>\
     <button class="btn msa-btn" data-action="bigger"><span class="glyphicon-zoom-in"></span>+</button>\
@@ -54,7 +58,12 @@ const View = BoneView.extend({
       colWidth: this.model.getColumnWidth(),
     };
     this.$el.html( this.template(stash) );
-    this.hide();    
+    if ( this.isVisible ) {
+      this.show();
+    }
+    else {
+      this.hide();
+    }
     return this;
   },
 
@@ -80,11 +89,13 @@ const View = BoneView.extend({
   },
   
   hide: function() {
+    this.isVisible = false;
     this.$el.find(".msa-scale-minimised").removeClass(this.toggleClass);
     this.$el.find(".msa-scale-maximised").addClass(this.toggleClass);
   },
 
   show: function() {
+    this.isVisible = false;
     this.$el.find(".msa-scale-minimised").addClass(this.toggleClass);
     this.$el.find(".msa-scale-maximised").removeClass(this.toggleClass);
   },

--- a/src/views/Stage.js
+++ b/src/views/Stage.js
@@ -5,6 +5,7 @@ import AlignmentBody from "./AlignmentBody";
 import HeaderBlock from "./header/HeaderBlock";
 import OverviewBox from "./OverviewBox";
 import Search from "./Search";
+import ScaleSlider from "./ScaleSlider";
 
 // a neat collection view
 const View  = boneView.extend({
@@ -29,7 +30,10 @@ const View  = boneView.extend({
 
     this.listenTo(this.g.vis,"change:sequences", this.rerender);
     this.listenTo(this.g.vis,"change:overviewbox", this.rerender);
-    return this.listenTo(this.g.visorder,"change", this.rerender);
+    this.listenTo(this.g.visorder,"change", this.rerender);
+    this.listenTo(this.g.zoomer, "change:columnWidth", this.rerender);
+
+    return this;
   },
 
   draw: function() {
@@ -55,13 +59,23 @@ const View  = boneView.extend({
 
     var body = new AlignmentBody({model: this.model, g: this.g});
     body.ordering = this.g.visorder.get('alignmentBody');
-    return this.addView("body",body);
+    this.addView("body",body);
+
+    if (this.g.vis.get("scaleslider")) {
+      var scaleslider = new ScaleSlider({model: this.g.scale, g: this.g});
+      //console.log( "scaleslider", scaleslider )
+      scaleslider.ordering = this.g.visorder.get('scaleSlider');
+      this.addView("scaleSlider", scaleslider);
+    }
+    
+    return this;
   },
 
-  render: function() {
+  render: function(e) {
+    console.log( "Stage.render.START" );
     this.renderSubviews();
     this.el.className = "biojs_msa_stage";
-
+    console.log( "Stage.render.DONE" );
     return this;
   },
 

--- a/src/views/Stage.js
+++ b/src/views/Stage.js
@@ -63,19 +63,17 @@ const View  = boneView.extend({
 
     if (this.g.vis.get("scaleslider")) {
       var scaleslider = new ScaleSlider({model: this.g.scale, g: this.g});
-      //console.log( "scaleslider", scaleslider )
       scaleslider.ordering = this.g.visorder.get('scaleSlider');
       this.addView("scaleSlider", scaleslider);
+      scaleslider.syncModel();
     }
     
     return this;
   },
 
   render: function(e) {
-    console.log( "Stage.render.START" );
     this.renderSubviews();
     this.el.className = "biojs_msa_stage";
-    console.log( "Stage.render.DONE" );
     return this;
   },
 

--- a/src/views/canvas/CanvasSeqDrawer.js
+++ b/src/views/canvas/CanvasSeqDrawer.js
@@ -1,18 +1,30 @@
 const _ = require("underscore");
 
-const Drawer =
+const Drawer = {
+    
+  updateRectWidth: function() {
+    this.rectWidth = this.g.zoomer.get('columnWidth');
+  },
+  
+  drawLetters: function() {
 
-  {drawLetters: function() {
-
+    this.updateRectWidth();
+    
     var rectHeight = this.rectHeight;
-
+    var rectWidth = this.rectWidth;
+    var minLetterDrawSize = 7;
+    
     // rects
     this.ctx.globalAlpha = this.g.colorscheme.get("opacity");
     this.drawSeqs(function(data) { return this.drawSeq(data, this._drawRect); });
     this.ctx.globalAlpha = 1;
 
     // letters
-    return this.drawSeqs(function(data) { return this.drawSeq(data, this._drawLetter); });
+    if ( rectWidth >= minLetterDrawSize ) {
+      this.drawSeqs(function(data) { return this.drawSeq(data, this._drawLetter); });
+    }
+    
+    return this;
   },
 
   drawSeqs: function(callback, target) {
@@ -156,7 +168,7 @@ const CanvasSeqDrawer = function(g,ctx,model,opts) {
   this.color = opts.color;
   this.cache = opts.cache;
   this.rectHeight = this.g.zoomer.get("rowHeight");
-  this.rectWidth = this.g.zoomer.get("columnWidth");
+  this.rectWidth = this.g.zoomer.get("columnWidth"); // note: this can change
   return this;
 };
 

--- a/src/views/header/MarkerView.js
+++ b/src/views/header/MarkerView.js
@@ -16,35 +16,39 @@ const MarkerView = view.extend({
 
   render: function() {
     dom.removeAllChilds(this.el);
+    
+    var fontSize = this.g.zoomer.get("markerFontsize");
+    var cellWidth = this.g.zoomer.get("columnWidth");
+    var stepSize = this.g.zoomer.get("stepSize");
+    var markerStepSize = this.g.zoomer.get("markerStepSize");
 
-    this.el.style.fontSize = this.g.zoomer.get("markerFontsize");
+    var hidden = this.g.columns.get("hidden");
+    
+    this.el.style.fontSize = fontSize;
 
     var container = document.createElement("span");
     var n = 0;
-    var cellWidth = this.g.zoomer.get("columnWidth");
-
     var nMax = this.model.getMaxLength();
-    var stepSize = this.g.zoomer.get("stepSize");
-    var hidden = this.g.columns.get("hidden");
 
-    while (n < nMax) {
+    for( var n=0; n < nMax; n++ ) {
       if (hidden.indexOf(n) >= 0) {
         this.markerHidden(span,n, stepSize);
         n += stepSize;
         continue;
       }
       var span = document.createElement("span");
-      span.style.width = (cellWidth * stepSize) + "px";
+      span.className = 'msa-col-header';
+      span.style.width = cellWidth + "px";
       span.style.display = "inline-block";
-      // TODO: this doesn't work for a larger stepSize
-      if ((n + 1) % this.g.zoomer.get('markerStepSize') === 0) {
+      
+      if ((n+1) % markerStepSize === 0) {
         span.textContent = (n + 1);
-      } else {
+      } else if ((n+1) % stepSize === 0) {
         span.textContent = ".";
+      } else {
+        span.textContent = " ";
       }
       span.rowPos = n;
-
-      n += stepSize;
       container.appendChild(span);
     }
 


### PR DESCRIPTION
Provides a control to change the horizontal scale of the main alignment window (```msa.g.zoomer.columnWidth```). 

Effectively lets you zoom in and out (horizontal).

Adds dependency: ```linear-scale``` (tiny)

I've left debug comments in while I'm investigating:
 * why everything seems to get rendered several times
 * improving the spacing of the fonts and markers