### PR TITLE
strip console.log on production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,11 @@
     "prunner": "^1.0.0",
     "sinon": "^1.12.1",
     "sniper": "^0.2.16",
+    "strip-loader": "^0.1.2",
     "style-loader": "^0.13.0",
     "through2": "^0.6.3",
     "tnt.tree": "0.1.4",
-    "uglify-js": "~2.4.15",
+    "uglify-js": "~2.6.2",
     "webpack": "^1.13.0"
   },
   "keywords": [

--- a/src/views/OverviewBox.js
+++ b/src/views/OverviewBox.js
@@ -61,7 +61,6 @@ const OverviewBox = view.extend({
 
       if (this.model.at(i).get("hidden")) {
         // hidden seq
-        console.log(this.model.at(i).get("hidden"));
         this.ctx.fillStyle = "grey";
         this.ctx.fillRect(0,y,seq.length * rectWidth,rectHeight);
         continue;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
+var prod = process.argv.indexOf('-p') >= 0;
+
 module.exports = {
     entry: './src/index_webpack.js',
     output: {
@@ -19,6 +21,23 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             MSA_VERSION: JSON.stringify(require("./package.json").version)
-        })
-    ]
+        }),
+    ],
 };
+var w = module.exports;
+
+// only executed with -p
+if(prod) {
+    w.plugins.push(
+        new webpack.optimize.UglifyJsPlugin({
+            compress: {
+                collapse_vars: true
+            },
+        sourceMap: true
+    }));
+    var WebpackStrip = require('strip-loader');
+    w.module.loaders.push(
+        {   test: path.join(__dirname, 'src'),
+         loader: WebpackStrip.loader('console.log') }
+    );
+}


### PR DESCRIPTION
Will remove all `console.log` from our production build - we can continue to issue errors with `console.error` for now, but we really should trigger proper errors that are visible to the user.

Note: The stripping is not [perfect](https://github.com/yahoo/strip-loader/issues/12), it doesn't like functions in `console.log` hence I edited OverviewBox.