### PR TITLE
scale should not overwrite custom columnWidth

### DIFF
--- a/snippets/scale.js
+++ b/snippets/scale.js
@@ -6,6 +6,9 @@ var opts = {
   bootstrapMenu: true, // simplified behavior to add the menu bar, you can also create your own menu instance
   vis: {
     scaleslider: true
+  },
+  zoomer: {
+    columnWidth: 18, // take into account custom columnWidth
   }
 };
 var m = new msa(opts);

--- a/src/g/StageScale.js
+++ b/src/g/StageScale.js
@@ -24,16 +24,44 @@ module.exports = StageScale = Model.extend({
       { columnWidth: 15, markerStepSize: 2, stepSize: 1 },
       { columnWidth: 20, markerStepSize: 1, stepSize: 1 },
       { columnWidth: 30, markerStepSize: 1, stepSize: 1 },
+      { columnWidth: 45, markerStepSize: 1, stepSize: 1 },
     ],
   },
 
   initialize: function(args) {
+    const categories = this.get('scaleCategories');
+    const initialColumnWidth = this.g.zoomer.get('columnWidth') || this._getScaleInfo().columnWidth;
+
+    /* if the global columnWidth setting doesn't match any of our categories
+     * then create a category that does match and add it to a sensible place
+     * in the list
+     */
+    var category = _.find( categories, function(c) { return c.columnWidth == initialColumnWidth });
+    if (!category) {
+      const catindex = this._insertScaleCategory( initialColumnWidth );
+      category = categories[ catindex ];
+      // custom columnWidth should overwrite the default currentSize
+      this.set('currentSize', catindex + 1);
+    }
+
     const currentSize = this.get('currentSize');
     this.set('originalSize', currentSize);
-    // TODO: don't overwrite the default settings
-    //this.setSize( currentSize );
+    this.setSize(currentSize);
 
     return this;
+  },
+
+  // insert new category based on columnWidth
+  // return the index of newly inserted category
+  _insertScaleCategory: function(columnWidth) {
+    var categories = this.get('scaleCategories');
+    const lastcatindex = _.findLastIndex( categories, function(c) { return c.columnWidth < columnWidth });
+    const lastcat = categories[lastcatindex];
+    const insertindex = lastcatindex + 1;
+    const category = { columnWidth: columnWidth, markerStepSize: lastcat.markerStepSize, stepSize: lastcat.markerStepSize };
+    categories.splice( insertindex, 0, category );
+    this.set('scaleCategories', categories);
+    return insertindex;
   },
 
   getSizeRange() {
@@ -88,4 +116,3 @@ module.exports = StageScale = Model.extend({
     }
   }
 });
-


### PR DESCRIPTION
if the initial columnWidth is specified in the main config then the
scale component should add a new category to include this value in the
slider options (rather than overwrite).