### PR TITLE
Added a bit of logic to tree.js which tries to match tree leaves with…

### DIFF
--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -33,8 +33,24 @@ var tf =
         treeDiv.innerHTML = '';
       }
 
+      const seqs = this.msa.seqs.toJSON();
+      //adapt tree ids to sequence ids
+      function iterateTree(nwck){
+        if(nwck.children != null){
+          nwck.children.forEach(x => iterateTree(x));
+        } else {
+          //found a leave
+          let seq = seqs.filter(s => s.name === nwck.name)[0];
+          if(seq != null){
+            seq.ids = [seq.id];
+            nwck.name = seq.id;
+          }
+        }
+      }
+      iterateTree(newickObj);
+
       var nodes = mt.app({
-        seqs: this.msa.seqs.toJSON(),
+        seqs: seqs,
         tree: newickObj
       });
 


### PR DESCRIPTION
… MSA sequences. This allows users to upload tree files that have the same names OR IDs as the MSA sequences, whereas before only IDs were considered.

This should make tree file uploads much more intuitive.

Hope this works after rebase