### PR TITLE
hide non-polymorphic sites feature added to the filter menu

### DIFF
--- a/src/menu/views/FilterMenu.js
+++ b/src/menu/views/FilterMenu.js
@@ -25,6 +25,22 @@ const FilterMenu = MenuBuilder.extend({
       return this.g.columns.set("hidden", hidden);
     });
 
+    this.addNode("Hide non-polymorphic sites",(e) => {
+      var threshold = prompt("Enter identity threshold (in percent)", 100);
+      threshold = threshold / 100;
+      var maxLen = this.model.getMaxLength();
+      var hidden = [];
+      // TODO: cache this value
+      var conserv = this.g.stats.scale(this.g.stats.conservation());
+      var end = maxLen - 1;
+      for (var i = 0; 0 < end ? i <= end : i >= end; 0 < end ? i++ : i--) {
+        if (conserv[i] >= threshold) {
+          hidden.push(i);
+        }
+      }
+      return this.g.columns.set("hidden", hidden);
+    });
+
     this.addNode("Hide columns by selection", () => {
       var hiddenOld = this.g.columns.get("hidden");
       var hidden = hiddenOld.concat(this.g.selcol.getAllColumnBlocks({maxLen: this.model.getMaxLength(), withPos: true}));


### PR DESCRIPTION
Option to hide non-polymorphic sites. It hides the columns which nucleotide identity at a given position is above the threshold. 

Bruno Gonçalves