### PR TITLE
Overview size

### DIFF
--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -53,8 +53,8 @@ module.exports = Zoomer = Model.extend({
     boxRectHeight: 2,
     boxRectWidth: 2,
     overviewboxPaddingTop: 10,
-    overviewboxWidth: "auto",  // "auto" (fitting div) or "fixed"
-    overviewboxHeight: 200,    // "fixed" or in px
+    overviewboxWidth: "fixed",   // "auto" (fitting div) or "fixed"
+    overviewboxHeight: "fixed",  // "fixed" or in px
 
     // meta cell
     metaGapWidth: 35,

--- a/src/g/zoomer.js
+++ b/src/g/zoomer.js
@@ -53,6 +53,8 @@ module.exports = Zoomer = Model.extend({
     boxRectHeight: 2,
     boxRectWidth: 2,
     overviewboxPaddingTop: 10,
+    overviewboxWidth: "auto",  // "auto" (fitting div) or "fixed"
+    overviewboxHeight: 200,    // "fixed" or in px
 
     // meta cell
     metaGapWidth: 35,


### PR DESCRIPTION
This is a pull request to fix the issue in #207, i.e. it rescales the overview view to the size of the parent div, if zoomer.overviewboxWidth === 'auto' and limits the height of the overview if zoomer.overviewboxHeight is set to a fixed size. The default behaviour (parameters both set to 'fixed', the existing behaviour is maintained.
