### PR TITLE
syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ zoomer: {
     alignmentHeight: 225,
     columnWidth: 15,
     rowHeight: 15,
-    autoResize: true // only for the width
+    autoResize: true, // only for the width
 
     // labels
     textVisible: true,


### PR DESCRIPTION
There is a syntax error in README.
r? @wilzbach 